### PR TITLE
remove extra grant statuses in GrantStatus schema

### DIFF
--- a/specs/v1.yaml
+++ b/specs/v1.yaml
@@ -1309,9 +1309,6 @@ components:
           type: string
           enum:
             - Initiated
-            - Processing
-            - Received
-            - Payment Pending
             - Completed
             - Canceled
           description: |


### PR DESCRIPTION
These were removed in another portion of the docs, this is just to sync this