### PR TITLE
add supportedOnly flag

### DIFF
--- a/postman/collections/Chariot API.json
+++ b/postman/collections/Chariot API.json
@@ -5009,6 +5009,11 @@
 							],
 							"query": [
 								{
+									"description": "Whether to return only supported DAFs; defaults to false",
+									"key": "supportedOnly",
+									"value": "false"
+								},
+								{
 									"description": "the number of results to return; defaults to 10, max is 100",
 									"key": "pageLimit",
 									"value": "10"

--- a/specs/v1.yaml
+++ b/specs/v1.yaml
@@ -731,6 +731,13 @@ paths:
       tags:
         - DAFs
       parameters:
+        - name: supportedOnly
+          in: query
+          description: |-
+            If set to true, filters DAFs to only those that have a direct integration with Chariot.
+          schema:
+            type: boolean
+            default: false
         - name: pageLimit
           in: query
           description: the number of results to return; defaults to 10, max is 100


### PR DESCRIPTION
Adds the supportedOnly flag to the docs.

VSCode's whitespacing got to the rest of the file.  Meh.  I can back it out if people want, but 🤷 