### PR TITLE
feat(docs): require authorization for list + get to DAFs endpoints

### DIFF
--- a/specs/2025-02-24.yaml
+++ b/specs/2025-02-24.yaml
@@ -564,6 +564,8 @@ paths:
       operationId: list-dafs
       tags:
         - Donor Advised Funds
+      security:
+        - bearerAuth: []
       parameters:
         - name: supportedOnly
           in: query
@@ -595,6 +597,8 @@ paths:
           $ref: "#/components/responses/ListDafsResponse"
         "400":
           $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /v1/dafs/{id}:
@@ -605,6 +609,8 @@ paths:
       operationId: get-daf
       tags:
         - Donor Advised Funds
+      security:
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -631,6 +637,8 @@ paths:
                   $ref: "#/components/examples/DafOutput"
         "400":
           $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
         "404":
           $ref: "#/components/responses/NotFoundError"
         "500":


### PR DESCRIPTION
This PR adds a requirement in our documentation for users to provide an authorization token to list or get DAFs.

We are migrating over the DAFs service (see https://github.com/chariot-giving/chariot/pull/7288) to Axle out of Orchestration, and Axle does not currently support fully public/unauthorized APIs (nor is this a good idea).

NOTE: I'm not going to bother actually migrating Orchestration to check this token.
