### PR TITLE
fix: cds lockbox request

### DIFF
--- a/fern/apis/2026-01-15/openapi-overrides.yml
+++ b/fern/apis/2026-01-15/openapi-overrides.yml
@@ -263,9 +263,8 @@ paths:
       x-fern-sdk-group-name:
         - mailbox
       x-fern-sdk-method-name: getUploadUrl
-  /v1/mailbox/provision:
+  /v1/lockboxes/fulfill_request:
     post:
       x-fern-sdk-group-name:
         - mailbox
-      x-fern-sdk-method-name: provision
-
+      x-fern-sdk-method-name: fulfillRequest

--- a/fern/apis/2026-04-01/openapi-overrides.yml
+++ b/fern/apis/2026-04-01/openapi-overrides.yml
@@ -263,9 +263,8 @@ paths:
       x-fern-sdk-group-name:
         - mailbox
       x-fern-sdk-method-name: getUploadUrl
-  /v1/mailbox/provision:
+  /v1/lockboxes/fulfill_request:
     post:
       x-fern-sdk-group-name:
         - mailbox
-      x-fern-sdk-method-name: provision
-
+      x-fern-sdk-method-name: fulfillRequest

--- a/fern/versions/v2026-01-15/docs.yml
+++ b/fern/versions/v2026-01-15/docs.yml
@@ -175,8 +175,6 @@ navigation:
             skip-slug: true
             icon: money-check
             contents:
-              - financialAccounts:
-                  title: Financial Accounts
               - inboundTransfers:
                   title: Inbound Transfers
               - disbursements:

--- a/fern/versions/v2026-01-15/pages/lockbox-providers/provisioning.mdx
+++ b/fern/versions/v2026-01-15/pages/lockbox-providers/provisioning.mdx
@@ -4,7 +4,7 @@ createdAt: "Fri Mar 13 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Fri Mar 13 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
 ---
 
-For dedicated PO boxes, the provisioning flow is as follows. See the [Provision a Mailbox](/v2026-01-15/api/mailbox/provision) API reference for endpoint details.
+For dedicated PO boxes, the provisioning flow is as follows. See the [Provision a Lockbox](/v2026-01-15/api/lockbox/provision) API reference for endpoint details.
 
 Also see: [Mail Uploads](/v2026-01-15/guides/lockbox-providers/mail-uploads) | [Rescans](/v2026-01-15/guides/lockbox-providers/mail-uploads#rescans)
 
@@ -25,10 +25,17 @@ The provider reserves and sets up the new PO box (e.g., PO 9876).
 
 Once the PO box is live, the provider sends a request to the Chariot provisioning endpoint:
 
-```json title="POST /mailbox/provision"
+```json title="POST /lockbox/provision"
 {
   "request_id": "req_01kkmjrdgdjtwgk7wdkba1kn9s",
-  "location_id": "po_9876"
+  "location_id": "po_9876",
+  "address": {
+    "line1": "123 Main St"
+    "line2": "STE 12345",
+    "city": "New York",
+    "state": "NY",
+    "zip": "12345-1234"
+  }
 }
 ```
 

--- a/fern/versions/v2026-01-15/pages/lockbox-providers/provisioning.mdx
+++ b/fern/versions/v2026-01-15/pages/lockbox-providers/provisioning.mdx
@@ -30,7 +30,7 @@ Once the PO box is live, the provider sends a request to the Chariot provisionin
   "request_id": "req_01kkmjrdgdjtwgk7wdkba1kn9s",
   "location_id": "po_9876",
   "address": {
-    "line1": "123 Main St"
+    "line1": "123 Main St",
     "line2": "STE 12345",
     "city": "New York",
     "state": "NY",

--- a/fern/versions/v2026-04-01/docs.yml
+++ b/fern/versions/v2026-04-01/docs.yml
@@ -175,8 +175,6 @@ navigation:
             skip-slug: true
             icon: money-check
             contents:
-              - financialAccounts:
-                  title: Financial Accounts
               - inboundTransfers:
                   title: Inbound Transfers
               - disbursements:

--- a/fern/versions/v2026-04-01/pages/lockbox-providers/provisioning.mdx
+++ b/fern/versions/v2026-04-01/pages/lockbox-providers/provisioning.mdx
@@ -4,7 +4,7 @@ createdAt: "Fri Mar 13 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Fri Mar 13 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
 ---
 
-For dedicated PO boxes, the provisioning flow is as follows. See the [Provision a Mailbox](/v2026-01-15/api/mailbox/provision) API reference for endpoint details.
+For dedicated PO boxes, the provisioning flow is as follows. See the [Provision a Lockbox](/v2026-01-15/api/lockbox/provision) API reference for endpoint details.
 
 Also see: [Mail Uploads](/v2026-01-15/guides/lockbox-providers/mail-uploads) | [Rescans](/v2026-01-15/guides/lockbox-providers/mail-uploads#rescans)
 
@@ -25,10 +25,17 @@ The provider reserves and sets up the new PO box (e.g., PO 9876).
 
 Once the PO box is live, the provider sends a request to the Chariot provisioning endpoint:
 
-```json title="POST /mailbox/provision"
+```json title="POST /lockbox/provision"
 {
   "request_id": "req_01kkmjrdgdjtwgk7wdkba1kn9s",
-  "location_id": "po_9876"
+  "location_id": "po_9876",
+  "address": {
+    "line1": "123 Main St"
+    "line2": "STE 12345",
+    "city": "New York",
+    "state": "NY",
+    "zip": "12345-1234"
+  }
 }
 ```
 

--- a/fern/versions/v2026-04-01/pages/lockbox-providers/provisioning.mdx
+++ b/fern/versions/v2026-04-01/pages/lockbox-providers/provisioning.mdx
@@ -30,7 +30,7 @@ Once the PO box is live, the provider sends a request to the Chariot provisionin
   "request_id": "req_01kkmjrdgdjtwgk7wdkba1kn9s",
   "location_id": "po_9876",
   "address": {
-    "line1": "123 Main St"
+    "line1": "123 Main St",
     "line2": "STE 12345",
     "city": "New York",
     "state": "NY",

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2282,9 +2282,9 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /v1/mailbox/provision:
+  /v1/lockboxes/fulfill_request:
     post:
-      summary: Provision a Mailbox
+      summary: Fulfill a Lockbox Request
       description: |-
         Notifies Chariot that a new PO box has been provisioned by the lockbox provider.
 
@@ -2305,6 +2305,7 @@ paths:
               required:
                 - request_id
                 - location_id
+                - address
               properties:
                 request_id:
                   type: string
@@ -2314,6 +2315,8 @@ paths:
                   type: string
                   description: The identifier of the newly provisioned PO box.
                   example: "po_9876"
+                address:
+                  $ref: "#/components/schemas/Address"
       responses:
         "204":
           description: Indicates the PO box has been successfully provisioned.

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2318,7 +2318,7 @@ paths:
                 address:
                   $ref: "#/components/schemas/Address"
       responses:
-        "204":
+        "200":
           description: Indicates the PO box has been successfully provisioned.
         "400":
           $ref: "#/components/responses/BadRequestError"

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2323,7 +2323,7 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/component/s/responses/AuthenticationError"
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "500":

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2323,7 +2323,7 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/component/s/responses/AuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "500":

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2285,9 +2285,9 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /v1/mailbox/provision:
+  /v1/lockboxes/fulfill_request:
     post:
-      summary: Provision a Mailbox
+      summary: Fulfill a Lockbox Request
       description: |-
         Notifies Chariot that a new PO box has been provisioned by the lockbox provider.
 
@@ -2308,6 +2308,7 @@ paths:
               required:
                 - request_id
                 - location_id
+                - address
               properties:
                 request_id:
                   type: string
@@ -2317,17 +2318,8 @@ paths:
                   type: string
                   description: The identifier of the newly provisioned PO box.
                   example: "po_9876"
-      responses:
-        "204":
-          description: Indicates the PO box has been successfully provisioned.
-        "400":
-          $ref: "#/components/responses/BadRequestError"
-        "401":
-          $ref: "#/components/responses/AuthenticationError"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
+                address:
+                  $ref: "#/components/schemas/Address"
 components:
   securitySchemes:
     bearerAuth:
@@ -5649,10 +5641,7 @@ components:
                       donors:
                         {
                           primary_donor:
-                            {
-                              first_name: "Alice",
-                              last_name: "Williams",
-                            },
+                            { first_name: "Alice", last_name: "Williams" },
                         },
                       corporate_match: { company_name: "Acme Corporation" },
                     },

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2320,6 +2320,17 @@ paths:
                   example: "po_9876"
                 address:
                   $ref: "#/components/schemas/Address"
+      responses:
+        "200":
+          description: Indicates the PO box has been successfully provisioned.
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
updates `/guides/lockbox-providers/provisioning` and `/api/mailbox/fulfill-request`

Note: These are not public facing so they can only be read if you have direct links. Once we make these updates I'll give the correct links to the CDS team, same as we did for the version that this PR updates

The latest preview links are
These were never public facing, just direct links that we've shared with the CDS team

Here are the preview links

-  https://chariot-preview-4fcaea4f-d7b3-4b0c-9846-a41833cfe38b.docs.buildwithfern.com/v2026-01-15/api/mailbox/fulfill-request
- https://chariot-preview-4fcaea4f-d7b3-4b0c-9846-a41833cfe38b.docs.buildwithfern.com/v2026-01-15/guides/lockbox-providers/provisioning
