### PR TITLE
Add payment_status field to Donation

### DIFF
--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2834,6 +2834,18 @@ components:
             A non-null value indicates the donation is tied to a canceled grant initiation
             and the gift was not received. Expressed in RFC 3339 format.
           example: "2020-01-31T23:59:59Z"
+        payment_status:
+          type: string
+          readOnly: true
+          description: The payment status of the donation. Indicates the current state of the payment lifecycle.
+          example: "PAYMENT_STATUS_INCOMING_TO_CHARIOT"
+          enum:
+            - PAYMENT_STATUS_UNSPECIFIED
+            - PAYMENT_STATUS_INCOMING_TO_CHARIOT
+            - PAYMENT_STATUS_INCOMING_OUTSIDE_CHARIOT
+            - PAYMENT_STATUS_RECEIVED_IN_CHARIOT
+            - PAYMENT_STATUS_RECEIVED_OUTSIDE_CHARIOT
+            - PAYMENT_STATUS_CANCELED
     Artifact:
       type: object
       description: |-

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2838,14 +2838,14 @@ components:
           type: string
           readOnly: true
           description: The payment status of the donation. Indicates the current state of the payment lifecycle.
-          example: "PAYMENT_STATUS_INCOMING_TO_CHARIOT"
+          example: "INCOMING_TO_CHARIOT"
           enum:
-            - PAYMENT_STATUS_UNSPECIFIED
-            - PAYMENT_STATUS_INCOMING_TO_CHARIOT
-            - PAYMENT_STATUS_INCOMING_OUTSIDE_CHARIOT
-            - PAYMENT_STATUS_RECEIVED_IN_CHARIOT
-            - PAYMENT_STATUS_RECEIVED_OUTSIDE_CHARIOT
-            - PAYMENT_STATUS_CANCELED
+            - UNSPECIFIED
+            - INCOMING_TO_CHARIOT
+            - INCOMING_OUTSIDE_CHARIOT
+            - RECEIVED_IN_CHARIOT
+            - RECEIVED_OUTSIDE_CHARIOT
+            - CANCELED
     Artifact:
       type: object
       description: |-

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2840,7 +2840,6 @@ components:
           description: The payment status of the donation. Indicates the current state of the payment lifecycle.
           example: "INCOMING_TO_CHARIOT"
           enum:
-            - UNSPECIFIED
             - INCOMING_TO_CHARIOT
             - INCOMING_OUTSIDE_CHARIOT
             - RECEIVED_IN_CHARIOT

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2843,7 +2843,6 @@ components:
           description: The payment status of the donation. Indicates the current state of the payment lifecycle.
           example: "INCOMING_TO_CHARIOT"
           enum:
-            - UNSPECIFIED
             - INCOMING_TO_CHARIOT
             - INCOMING_OUTSIDE_CHARIOT
             - RECEIVED_IN_CHARIOT

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2837,6 +2837,18 @@ components:
             A non-null value indicates the donation is tied to a canceled grant initiation
             and the gift was not received. Expressed in RFC 3339 format.
           example: "2020-01-31T23:59:59Z"
+        payment_status:
+          type: string
+          readOnly: true
+          description: The payment status of the donation. Indicates the current state of the payment lifecycle.
+          example: "PAYMENT_STATUS_INCOMING_TO_CHARIOT"
+          enum:
+            - PAYMENT_STATUS_UNSPECIFIED
+            - PAYMENT_STATUS_INCOMING_TO_CHARIOT
+            - PAYMENT_STATUS_INCOMING_OUTSIDE_CHARIOT
+            - PAYMENT_STATUS_RECEIVED_IN_CHARIOT
+            - PAYMENT_STATUS_RECEIVED_OUTSIDE_CHARIOT
+            - PAYMENT_STATUS_CANCELED
     Artifact:
       type: object
       description: |-

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2841,14 +2841,14 @@ components:
           type: string
           readOnly: true
           description: The payment status of the donation. Indicates the current state of the payment lifecycle.
-          example: "PAYMENT_STATUS_INCOMING_TO_CHARIOT"
+          example: "INCOMING_TO_CHARIOT"
           enum:
-            - PAYMENT_STATUS_UNSPECIFIED
-            - PAYMENT_STATUS_INCOMING_TO_CHARIOT
-            - PAYMENT_STATUS_INCOMING_OUTSIDE_CHARIOT
-            - PAYMENT_STATUS_RECEIVED_IN_CHARIOT
-            - PAYMENT_STATUS_RECEIVED_OUTSIDE_CHARIOT
-            - PAYMENT_STATUS_CANCELED
+            - UNSPECIFIED
+            - INCOMING_TO_CHARIOT
+            - INCOMING_OUTSIDE_CHARIOT
+            - RECEIVED_IN_CHARIOT
+            - RECEIVED_OUTSIDE_CHARIOT
+            - CANCELED
     Artifact:
       type: object
       description: |-


### PR DESCRIPTION
## Summary
- Adds a `payment_status` enum field to the Donation schema in both `v2026-04-01` and `v2026-01-15` API specs
- Enum values: `INCOMING_TO_CHARIOT`, `INCOMING_OUTSIDE_CHARIOT`, `RECEIVED_IN_CHARIOT`, `RECEIVED_OUTSIDE_CHARIOT`, `CANCELED`