### PR TITLE
feat(nonprofit): document grantmaker nonprofit address & contact upload endpoints

### DIFF
--- a/fern/apis/2026-01-15/openapi-overrides.yml
+++ b/fern/apis/2026-01-15/openapi-overrides.yml
@@ -268,8 +268,13 @@ paths:
       x-fern-sdk-group-name:
         - mailbox
       x-fern-sdk-method-name: fulfillRequest
+  /v1/nonprofit_addresses:
+    post:
+      x-fern-sdk-group-name:
+        - nonprofits
+      x-fern-sdk-method-name: createAddress
   /v1/nonprofit_contacts:
     post:
       x-fern-sdk-group-name:
-        - nonprofitContacts
-      x-fern-sdk-method-name: create
+        - nonprofits
+      x-fern-sdk-method-name: createContact

--- a/fern/apis/2026-01-15/openapi-overrides.yml
+++ b/fern/apis/2026-01-15/openapi-overrides.yml
@@ -271,10 +271,10 @@ paths:
   /v1/nonprofit_addresses:
     post:
       x-fern-sdk-group-name:
-        - nonprofits
-      x-fern-sdk-method-name: createAddress
+        - nonprofitAddresses
+      x-fern-sdk-method-name: create
   /v1/nonprofit_contacts:
     post:
       x-fern-sdk-group-name:
-        - nonprofits
-      x-fern-sdk-method-name: createContact
+        - nonprofitContacts
+      x-fern-sdk-method-name: create

--- a/fern/apis/2026-01-15/openapi-overrides.yml
+++ b/fern/apis/2026-01-15/openapi-overrides.yml
@@ -268,3 +268,8 @@ paths:
       x-fern-sdk-group-name:
         - mailbox
       x-fern-sdk-method-name: fulfillRequest
+  /v1/nonprofit_contacts:
+    post:
+      x-fern-sdk-group-name:
+        - nonprofitContacts
+      x-fern-sdk-method-name: create

--- a/fern/apis/2026-04-01/openapi-overrides.yml
+++ b/fern/apis/2026-04-01/openapi-overrides.yml
@@ -268,8 +268,13 @@ paths:
       x-fern-sdk-group-name:
         - mailbox
       x-fern-sdk-method-name: fulfillRequest
+  /v1/nonprofit_addresses:
+    post:
+      x-fern-sdk-group-name:
+        - nonprofits
+      x-fern-sdk-method-name: createAddress
   /v1/nonprofit_contacts:
     post:
       x-fern-sdk-group-name:
-        - nonprofitContacts
-      x-fern-sdk-method-name: create
+        - nonprofits
+      x-fern-sdk-method-name: createContact

--- a/fern/apis/2026-04-01/openapi-overrides.yml
+++ b/fern/apis/2026-04-01/openapi-overrides.yml
@@ -271,10 +271,10 @@ paths:
   /v1/nonprofit_addresses:
     post:
       x-fern-sdk-group-name:
-        - nonprofits
-      x-fern-sdk-method-name: createAddress
+        - nonprofitAddresses
+      x-fern-sdk-method-name: create
   /v1/nonprofit_contacts:
     post:
       x-fern-sdk-group-name:
-        - nonprofits
-      x-fern-sdk-method-name: createContact
+        - nonprofitContacts
+      x-fern-sdk-method-name: create

--- a/fern/apis/2026-04-01/openapi-overrides.yml
+++ b/fern/apis/2026-04-01/openapi-overrides.yml
@@ -268,3 +268,8 @@ paths:
       x-fern-sdk-group-name:
         - mailbox
       x-fern-sdk-method-name: fulfillRequest
+  /v1/nonprofit_contacts:
+    post:
+      x-fern-sdk-group-name:
+        - nonprofitContacts
+      x-fern-sdk-method-name: create

--- a/fern/versions/v2026-01-15/docs.yml
+++ b/fern/versions/v2026-01-15/docs.yml
@@ -181,6 +181,8 @@ navigation:
                   title: Disbursements
               - verificationRequests:
                   title: Verification Requests
+              - nonprofitContacts:
+                  title: Nonprofit Contacts
           - section: Gift Processing
             skip-slug: true
             icon: gear

--- a/fern/versions/v2026-01-15/docs.yml
+++ b/fern/versions/v2026-01-15/docs.yml
@@ -181,8 +181,10 @@ navigation:
                   title: Disbursements
               - verificationRequests:
                   title: Verification Requests
-              - nonprofits:
-                  title: Nonprofits
+              - nonprofitAddresses:
+                  title: Nonprofit Addresses
+              - nonprofitContacts:
+                  title: Nonprofit Contacts
           - section: Gift Processing
             skip-slug: true
             icon: gear

--- a/fern/versions/v2026-01-15/docs.yml
+++ b/fern/versions/v2026-01-15/docs.yml
@@ -181,8 +181,8 @@ navigation:
                   title: Disbursements
               - verificationRequests:
                   title: Verification Requests
-              - nonprofitContacts:
-                  title: Nonprofit Contacts
+              - nonprofits:
+                  title: Nonprofits
           - section: Gift Processing
             skip-slug: true
             icon: gear

--- a/fern/versions/v2026-04-01/docs.yml
+++ b/fern/versions/v2026-04-01/docs.yml
@@ -181,6 +181,8 @@ navigation:
                   title: Disbursements
               - verificationRequests:
                   title: Verification Requests
+              - nonprofitContacts:
+                  title: Nonprofit Contacts
           - section: Gift Processing
             skip-slug: true
             icon: gear

--- a/fern/versions/v2026-04-01/docs.yml
+++ b/fern/versions/v2026-04-01/docs.yml
@@ -181,8 +181,10 @@ navigation:
                   title: Disbursements
               - verificationRequests:
                   title: Verification Requests
-              - nonprofits:
-                  title: Nonprofits
+              - nonprofitAddresses:
+                  title: Nonprofit Addresses
+              - nonprofitContacts:
+                  title: Nonprofit Contacts
           - section: Gift Processing
             skip-slug: true
             icon: gear

--- a/fern/versions/v2026-04-01/docs.yml
+++ b/fern/versions/v2026-04-01/docs.yml
@@ -181,8 +181,8 @@ navigation:
                   title: Disbursements
               - verificationRequests:
                   title: Verification Requests
-              - nonprofitContacts:
-                  title: Nonprofit Contacts
+              - nonprofits:
+                  title: Nonprofits
           - section: Gift Processing
             skip-slug: true
             icon: gear

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2328,25 +2328,47 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/nonprofit_addresses:
+    post:
+      summary: Create Nonprofit Addresses
+      description: |-
+        Upload mailing addresses you have on file for nonprofits you fund.
+        Each entry is matched to a nonprofit by its EIN.
+
+        Uploaded addresses are used as suggestions for where to send
+        disbursements.
+      operationId: createNonprofitAddressSuggestion
+      tags:
+        - nonprofits
+      security:
+        - bearerAuth: []
+      requestBody:
+        $ref: "#/components/requestBodies/CreateNonprofitAddressSuggestionRequest"
+      responses:
+        "200":
+          description: All addresses were accepted.
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/nonprofit_contacts:
     post:
       summary: Create Nonprofit Contacts
       description: |-
-        Uploads one or more person-contact suggestions for nonprofits the
-        caller funds. Each entry is matched to a nonprofit by EIN.
+        Upload contact information you have on file for nonprofits you fund.
+        Each entry is matched to a nonprofit by its EIN.
 
-        Suggestions are append-only — multiple suggestions per nonprofit are
-        allowed and existing rows are never overwritten. Operators review
-        suggestions and, when verified, promote them into the canonical
-        contact used for disbursement claim-account emails.
-
-        Single-row uploads pass a one-element list; bulk CSV imports send up
-        to 500 entries in one request. If any entry's EIN does not match a
-        known nonprofit, the entire request is rejected and no rows are
-        written.
+        Uploaded contacts are used as suggestions for who to notify about
+        disbursements.
       operationId: createNonprofitContactSuggestion
       tags:
-        - nonprofitContacts
+        - nonprofits
       security:
         - bearerAuth: []
       requestBody:
@@ -2531,13 +2553,50 @@ components:
           $ref: "#/components/schemas/ComplianceRequirement"
         california_franchise_tax_board:
           $ref: "#/components/schemas/ComplianceRequirement"
+    NonprofitAddressSuggestionEntry:
+      type: object
+      description: A mailing address uploaded for a nonprofit, identified by its EIN.
+      required:
+        - ein
+        - line1
+        - city
+        - state
+        - zip
+      properties:
+        ein:
+          type: string
+          description: |-
+            The EIN of the nonprofit this address belongs to. Accepted as
+            either nine digits (`123456789`) or `XX-XXXXXXX`.
+          example: "13-1635294"
+        line1:
+          type: string
+          maxLength: 255
+          description: Street address.
+          example: "431 18th Street NW"
+        line2:
+          type: string
+          maxLength: 255
+          description: Optional suite, apartment, or unit.
+          example: "Suite 200"
+        city:
+          type: string
+          maxLength: 255
+          description: City.
+          example: "Washington"
+        state:
+          type: string
+          pattern: "^[A-Z]{2}$"
+          description: Two-letter US state code (uppercase).
+          example: "DC"
+        zip:
+          type: string
+          pattern: "^\\d{5}(-\\d{4})?$"
+          description: US ZIP code. Five digits, optionally followed by `-NNNN`.
+          example: "20006"
     NonprofitContactSuggestionEntry:
       type: object
-      description: |-
-        A single grantmaker-uploaded contact suggestion for a nonprofit.
-        The nonprofit is identified by `ein`. Suggestions are append-only
-        hints reviewed by operators before being promoted into the contact
-        used for disbursement claim-account emails.
+      description: A contact uploaded for a nonprofit, identified by its EIN.
       required:
         - ein
         - email
@@ -2558,7 +2617,7 @@ components:
           type: string
           maxLength: 255
           description: Optional phone number for the contact.
-          example: "+12025551212"
+          example: "2025551212"
         first_name:
           type: string
           maxLength: 255
@@ -5380,10 +5439,8 @@ components:
                 type: string
                 description: The unique identifier for the file to create a link for.
                 example: "file_01j8rs605a4gctmbm58d87mvsj"
-    CreateNonprofitContactSuggestionRequest:
-      description: |-
-        The request body for the Nonprofit Contacts.create endpoint.
-        Supply one or more entries, each identifying its nonprofit by EIN.
+    CreateNonprofitAddressSuggestionRequest:
+      description: Address entries to upload, each matched to a nonprofit by EIN.
       required: true
       content:
         application/json:
@@ -5394,10 +5451,37 @@ components:
             properties:
               entries:
                 type: array
-                description: |-
-                  List of contact suggestions to create. Each entry resolves its
-                  nonprofit by EIN. Up to 500 entries may be sent in a single
-                  request.
+                description: Address entries to upload. Up to 500 per request.
+                minItems: 1
+                maxItems: 500
+                items:
+                  $ref: "#/components/schemas/NonprofitAddressSuggestionEntry"
+            example:
+              entries:
+                - ein: "13-1635294"
+                  line1: "431 18th Street NW"
+                  city: "Washington"
+                  state: "DC"
+                  zip: "20006"
+                - ein: "530196605"
+                  line1: "1250 24th Street NW"
+                  line2: "Suite 300"
+                  city: "Washington"
+                  state: "DC"
+                  zip: "20037-1175"
+    CreateNonprofitContactSuggestionRequest:
+      description: Contact entries to upload, each matched to a nonprofit by EIN.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - entries
+            properties:
+              entries:
+                type: array
+                description: Contact entries to upload. Up to 500 per request.
                 minItems: 1
                 maxItems: 500
                 items:
@@ -5406,7 +5490,7 @@ components:
               entries:
                 - ein: "13-1635294"
                   email: "claims@redcross.org"
-                  phone: "+12025551212"
+                  phone: "2025551212"
                   first_name: "Sarah"
                   last_name: "Johnson"
                 - ein: "530196605"

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2332,11 +2332,8 @@ paths:
     post:
       summary: Create Nonprofit Addresses
       description: |-
-        Upload mailing addresses you have on file for nonprofits you fund.
-        Each entry is matched to a nonprofit by its EIN.
-
-        Uploaded addresses are used as suggestions for where to send
-        disbursements.
+        Submit mailing addresses for one or more nonprofits. Uploaded
+        addresses are used as suggestions for where to send disbursements.
       operationId: createNonprofitAddressSuggestion
       tags:
         - nonprofits
@@ -2361,11 +2358,8 @@ paths:
     post:
       summary: Create Nonprofit Contacts
       description: |-
-        Upload contact information you have on file for nonprofits you fund.
-        Each entry is matched to a nonprofit by its EIN.
-
-        Uploaded contacts are used as suggestions for who to notify about
-        disbursements.
+        Submit contact information for one or more nonprofits. Uploaded
+        contacts are used as suggestions for who to notify about disbursements.
       operationId: createNonprofitContactSuggestion
       tags:
         - nonprofits

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2328,6 +2328,42 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/nonprofit_contacts:
+    post:
+      summary: Create Nonprofit Contacts
+      description: |-
+        Uploads one or more person-contact suggestions for nonprofits the
+        caller funds. Each entry is matched to a nonprofit by EIN.
+
+        Suggestions are append-only — multiple suggestions per nonprofit are
+        allowed and existing rows are never overwritten. Operators review
+        suggestions and, when verified, promote them into the canonical
+        contact used for disbursement claim-account emails.
+
+        Single-row uploads pass a one-element list; bulk CSV imports send up
+        to 500 entries in one request. If any entry's EIN does not match a
+        known nonprofit, the entire request is rejected and no rows are
+        written.
+      operationId: createNonprofitContactSuggestion
+      tags:
+        - nonprofitContacts
+      security:
+        - bearerAuth: []
+      requestBody:
+        $ref: "#/components/requestBodies/CreateNonprofitContactSuggestionRequest"
+      responses:
+        "200":
+          description: All suggestions were accepted.
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 components:
   securitySchemes:
     bearerAuth:
@@ -2495,6 +2531,44 @@ components:
           $ref: "#/components/schemas/ComplianceRequirement"
         california_franchise_tax_board:
           $ref: "#/components/schemas/ComplianceRequirement"
+    NonprofitContactSuggestionEntry:
+      type: object
+      description: |-
+        A single grantmaker-uploaded contact suggestion for a nonprofit.
+        The nonprofit is identified by `ein`. Suggestions are append-only
+        hints reviewed by operators before being promoted into the contact
+        used for disbursement claim-account emails.
+      required:
+        - ein
+        - email
+      properties:
+        ein:
+          type: string
+          description: |-
+            The EIN of the nonprofit this contact belongs to. Accepted as
+            either nine digits (`123456789`) or `XX-XXXXXXX`.
+          example: "13-1635294"
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          description: Email of the contact person at the nonprofit.
+          example: "claims@redcross.org"
+        phone:
+          type: string
+          maxLength: 255
+          description: Optional phone number for the contact.
+          example: "+12025551212"
+        first_name:
+          type: string
+          maxLength: 255
+          description: Optional first name of the contact.
+          example: "Sarah"
+        last_name:
+          type: string
+          maxLength: 255
+          description: Optional last name of the contact.
+          example: "Johnson"
     Person:
       type: object
       description: |-
@@ -5306,6 +5380,37 @@ components:
                 type: string
                 description: The unique identifier for the file to create a link for.
                 example: "file_01j8rs605a4gctmbm58d87mvsj"
+    CreateNonprofitContactSuggestionRequest:
+      description: |-
+        The request body for the Nonprofit Contacts.create endpoint.
+        Supply one or more entries, each identifying its nonprofit by EIN.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - entries
+            properties:
+              entries:
+                type: array
+                description: |-
+                  List of contact suggestions to create. Each entry resolves its
+                  nonprofit by EIN. Up to 500 entries may be sent in a single
+                  request.
+                minItems: 1
+                maxItems: 500
+                items:
+                  $ref: "#/components/schemas/NonprofitContactSuggestionEntry"
+            example:
+              entries:
+                - ein: "13-1635294"
+                  email: "claims@redcross.org"
+                  phone: "+12025551212"
+                  first_name: "Sarah"
+                  last_name: "Johnson"
+                - ein: "530196605"
+                  email: "ap@worldwildlife.org"
     UpdateDonationRequest:
       description: |-
         The request to update core donation attributes like purpose, note and attribution.

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2586,13 +2586,11 @@ components:
           example: "Washington"
         state:
           type: string
-          pattern: "^[A-Z]{2}$"
           description: Two-letter US state code (uppercase).
           example: "DC"
         zip:
           type: string
-          pattern: "^\\d{5}(-\\d{4})?$"
-          description: US ZIP code. Five digits, optionally followed by `-NNNN`.
+          description: US ZIP code. Five digits, optionally followed by a four-digit extension.
           example: "20006"
     NonprofitContactSuggestionEntry:
       type: object

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2607,7 +2607,6 @@ components:
           example: "13-1635294"
         email:
           type: string
-          format: email
           maxLength: 255
           description: Email of the contact person at the nonprofit.
           example: "claims@redcross.org"

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2336,7 +2336,7 @@ paths:
         addresses are used as suggestions for where to send disbursements.
       operationId: createNonprofitAddressSuggestion
       tags:
-        - nonprofits
+        - nonprofitAddresses
       security:
         - bearerAuth: []
       requestBody:
@@ -2362,7 +2362,7 @@ paths:
         contacts are used as suggestions for who to notify about disbursements.
       operationId: createNonprofitContactSuggestion
       tags:
-        - nonprofits
+        - nonprofitContacts
       security:
         - bearerAuth: []
       requestBody:

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2589,13 +2589,11 @@ components:
           example: "Washington"
         state:
           type: string
-          pattern: "^[A-Z]{2}$"
           description: Two-letter US state code (uppercase).
           example: "DC"
         zip:
           type: string
-          pattern: "^\\d{5}(-\\d{4})?$"
-          description: US ZIP code. Five digits, optionally followed by `-NNNN`.
+          description: US ZIP code. Five digits, optionally followed by a four-digit extension.
           example: "20006"
     NonprofitContactSuggestionEntry:
       type: object

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2339,7 +2339,7 @@ paths:
         addresses are used as suggestions for where to send disbursements.
       operationId: createNonprofitAddressSuggestion
       tags:
-        - nonprofits
+        - nonprofitAddresses
       security:
         - bearerAuth: []
       requestBody:
@@ -2365,7 +2365,7 @@ paths:
         contacts are used as suggestions for who to notify about disbursements.
       operationId: createNonprofitContactSuggestion
       tags:
-        - nonprofits
+        - nonprofitContacts
       security:
         - bearerAuth: []
       requestBody:

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2331,25 +2331,47 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/nonprofit_addresses:
+    post:
+      summary: Create Nonprofit Addresses
+      description: |-
+        Upload mailing addresses you have on file for nonprofits you fund.
+        Each entry is matched to a nonprofit by its EIN.
+
+        Uploaded addresses are used as suggestions for where to send
+        disbursements.
+      operationId: createNonprofitAddressSuggestion
+      tags:
+        - nonprofits
+      security:
+        - bearerAuth: []
+      requestBody:
+        $ref: "#/components/requestBodies/CreateNonprofitAddressSuggestionRequest"
+      responses:
+        "200":
+          description: All addresses were accepted.
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/nonprofit_contacts:
     post:
       summary: Create Nonprofit Contacts
       description: |-
-        Uploads one or more person-contact suggestions for nonprofits the
-        caller funds. Each entry is matched to a nonprofit by EIN.
+        Upload contact information you have on file for nonprofits you fund.
+        Each entry is matched to a nonprofit by its EIN.
 
-        Suggestions are append-only — multiple suggestions per nonprofit are
-        allowed and existing rows are never overwritten. Operators review
-        suggestions and, when verified, promote them into the canonical
-        contact used for disbursement claim-account emails.
-
-        Single-row uploads pass a one-element list; bulk CSV imports send up
-        to 500 entries in one request. If any entry's EIN does not match a
-        known nonprofit, the entire request is rejected and no rows are
-        written.
+        Uploaded contacts are used as suggestions for who to notify about
+        disbursements.
       operationId: createNonprofitContactSuggestion
       tags:
-        - nonprofitContacts
+        - nonprofits
       security:
         - bearerAuth: []
       requestBody:
@@ -2534,13 +2556,50 @@ components:
           $ref: "#/components/schemas/ComplianceRequirement"
         california_franchise_tax_board:
           $ref: "#/components/schemas/ComplianceRequirement"
+    NonprofitAddressSuggestionEntry:
+      type: object
+      description: A mailing address uploaded for a nonprofit, identified by its EIN.
+      required:
+        - ein
+        - line1
+        - city
+        - state
+        - zip
+      properties:
+        ein:
+          type: string
+          description: |-
+            The EIN of the nonprofit this address belongs to. Accepted as
+            either nine digits (`123456789`) or `XX-XXXXXXX`.
+          example: "13-1635294"
+        line1:
+          type: string
+          maxLength: 255
+          description: Street address.
+          example: "431 18th Street NW"
+        line2:
+          type: string
+          maxLength: 255
+          description: Optional suite, apartment, or unit.
+          example: "Suite 200"
+        city:
+          type: string
+          maxLength: 255
+          description: City.
+          example: "Washington"
+        state:
+          type: string
+          pattern: "^[A-Z]{2}$"
+          description: Two-letter US state code (uppercase).
+          example: "DC"
+        zip:
+          type: string
+          pattern: "^\\d{5}(-\\d{4})?$"
+          description: US ZIP code. Five digits, optionally followed by `-NNNN`.
+          example: "20006"
     NonprofitContactSuggestionEntry:
       type: object
-      description: |-
-        A single grantmaker-uploaded contact suggestion for a nonprofit.
-        The nonprofit is identified by `ein`. Suggestions are append-only
-        hints reviewed by operators before being promoted into the contact
-        used for disbursement claim-account emails.
+      description: A contact uploaded for a nonprofit, identified by its EIN.
       required:
         - ein
         - email
@@ -2561,7 +2620,7 @@ components:
           type: string
           maxLength: 255
           description: Optional phone number for the contact.
-          example: "+12025551212"
+          example: "2025551212"
         first_name:
           type: string
           maxLength: 255
@@ -5414,10 +5473,8 @@ components:
                 type: string
                 description: The unique identifier for the file to create a link for.
                 example: "file_01j8rs605a4gctmbm58d87mvsj"
-    CreateNonprofitContactSuggestionRequest:
-      description: |-
-        The request body for the Nonprofit Contacts.create endpoint.
-        Supply one or more entries, each identifying its nonprofit by EIN.
+    CreateNonprofitAddressSuggestionRequest:
+      description: Address entries to upload, each matched to a nonprofit by EIN.
       required: true
       content:
         application/json:
@@ -5428,10 +5485,37 @@ components:
             properties:
               entries:
                 type: array
-                description: |-
-                  List of contact suggestions to create. Each entry resolves its
-                  nonprofit by EIN. Up to 500 entries may be sent in a single
-                  request.
+                description: Address entries to upload. Up to 500 per request.
+                minItems: 1
+                maxItems: 500
+                items:
+                  $ref: "#/components/schemas/NonprofitAddressSuggestionEntry"
+            example:
+              entries:
+                - ein: "13-1635294"
+                  line1: "431 18th Street NW"
+                  city: "Washington"
+                  state: "DC"
+                  zip: "20006"
+                - ein: "530196605"
+                  line1: "1250 24th Street NW"
+                  line2: "Suite 300"
+                  city: "Washington"
+                  state: "DC"
+                  zip: "20037-1175"
+    CreateNonprofitContactSuggestionRequest:
+      description: Contact entries to upload, each matched to a nonprofit by EIN.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - entries
+            properties:
+              entries:
+                type: array
+                description: Contact entries to upload. Up to 500 per request.
                 minItems: 1
                 maxItems: 500
                 items:
@@ -5440,7 +5524,7 @@ components:
               entries:
                 - ein: "13-1635294"
                   email: "claims@redcross.org"
-                  phone: "+12025551212"
+                  phone: "2025551212"
                   first_name: "Sarah"
                   last_name: "Johnson"
                 - ein: "530196605"

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2335,11 +2335,8 @@ paths:
     post:
       summary: Create Nonprofit Addresses
       description: |-
-        Upload mailing addresses you have on file for nonprofits you fund.
-        Each entry is matched to a nonprofit by its EIN.
-
-        Uploaded addresses are used as suggestions for where to send
-        disbursements.
+        Submit mailing addresses for one or more nonprofits. Uploaded
+        addresses are used as suggestions for where to send disbursements.
       operationId: createNonprofitAddressSuggestion
       tags:
         - nonprofits
@@ -2364,11 +2361,8 @@ paths:
     post:
       summary: Create Nonprofit Contacts
       description: |-
-        Upload contact information you have on file for nonprofits you fund.
-        Each entry is matched to a nonprofit by its EIN.
-
-        Uploaded contacts are used as suggestions for who to notify about
-        disbursements.
+        Submit contact information for one or more nonprofits. Uploaded
+        contacts are used as suggestions for who to notify about disbursements.
       operationId: createNonprofitContactSuggestion
       tags:
         - nonprofits

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2331,6 +2331,42 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/nonprofit_contacts:
+    post:
+      summary: Create Nonprofit Contacts
+      description: |-
+        Uploads one or more person-contact suggestions for nonprofits the
+        caller funds. Each entry is matched to a nonprofit by EIN.
+
+        Suggestions are append-only — multiple suggestions per nonprofit are
+        allowed and existing rows are never overwritten. Operators review
+        suggestions and, when verified, promote them into the canonical
+        contact used for disbursement claim-account emails.
+
+        Single-row uploads pass a one-element list; bulk CSV imports send up
+        to 500 entries in one request. If any entry's EIN does not match a
+        known nonprofit, the entire request is rejected and no rows are
+        written.
+      operationId: createNonprofitContactSuggestion
+      tags:
+        - nonprofitContacts
+      security:
+        - bearerAuth: []
+      requestBody:
+        $ref: "#/components/requestBodies/CreateNonprofitContactSuggestionRequest"
+      responses:
+        "200":
+          description: All suggestions were accepted.
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 components:
   securitySchemes:
     bearerAuth:
@@ -2498,6 +2534,44 @@ components:
           $ref: "#/components/schemas/ComplianceRequirement"
         california_franchise_tax_board:
           $ref: "#/components/schemas/ComplianceRequirement"
+    NonprofitContactSuggestionEntry:
+      type: object
+      description: |-
+        A single grantmaker-uploaded contact suggestion for a nonprofit.
+        The nonprofit is identified by `ein`. Suggestions are append-only
+        hints reviewed by operators before being promoted into the contact
+        used for disbursement claim-account emails.
+      required:
+        - ein
+        - email
+      properties:
+        ein:
+          type: string
+          description: |-
+            The EIN of the nonprofit this contact belongs to. Accepted as
+            either nine digits (`123456789`) or `XX-XXXXXXX`.
+          example: "13-1635294"
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          description: Email of the contact person at the nonprofit.
+          example: "claims@redcross.org"
+        phone:
+          type: string
+          maxLength: 255
+          description: Optional phone number for the contact.
+          example: "+12025551212"
+        first_name:
+          type: string
+          maxLength: 255
+          description: Optional first name of the contact.
+          example: "Sarah"
+        last_name:
+          type: string
+          maxLength: 255
+          description: Optional last name of the contact.
+          example: "Johnson"
     Person:
       type: object
       description: |-
@@ -5340,6 +5414,37 @@ components:
                 type: string
                 description: The unique identifier for the file to create a link for.
                 example: "file_01j8rs605a4gctmbm58d87mvsj"
+    CreateNonprofitContactSuggestionRequest:
+      description: |-
+        The request body for the Nonprofit Contacts.create endpoint.
+        Supply one or more entries, each identifying its nonprofit by EIN.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - entries
+            properties:
+              entries:
+                type: array
+                description: |-
+                  List of contact suggestions to create. Each entry resolves its
+                  nonprofit by EIN. Up to 500 entries may be sent in a single
+                  request.
+                minItems: 1
+                maxItems: 500
+                items:
+                  $ref: "#/components/schemas/NonprofitContactSuggestionEntry"
+            example:
+              entries:
+                - ein: "13-1635294"
+                  email: "claims@redcross.org"
+                  phone: "+12025551212"
+                  first_name: "Sarah"
+                  last_name: "Johnson"
+                - ein: "530196605"
+                  email: "ap@worldwildlife.org"
     UpdateDonationRequest:
       description: |-
         The request to update core donation attributes like purpose, note and attribution.

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2610,7 +2610,6 @@ components:
           example: "13-1635294"
         email:
           type: string
-          format: email
           maxLength: 255
           description: Email of the contact person at the nonprofit.
           example: "claims@redcross.org"


### PR DESCRIPTION
## Summary

Documents two grantmaker upload endpoints that already ship in axle:

- `POST /v1/nonprofit_addresses` — upload mailing-address suggestions used to inform where disbursements are sent.
- `POST /v1/nonprofit_contacts` — upload contact-info suggestions used to inform who is notified about disbursements.

Both endpoints are added to the `2026-01-15` and `2026-04-01` specs. Each accepts a list of entries (1–500), matches each entry to a nonprofit by EIN, and rejects the whole request if any EIN is unknown.

## Surface

- Tag: `nonprofits` (shared SDK group). Methods: `nonprofits.createAddress(...)`, `nonprofits.createContact(...)`.
- Rendered under the existing **Disbursements** section in the docs sidebar as a single "Nonprofits" entry.
- `fern check` passes locally with no new warnings.