### PR TITLE
docs(dafpay): document Content Security Policy prerequisites for the DAFpay integration

### DIFF
--- a/fern/versions/v2026-01-15/pages/integrating-dafpay/integration.mdx
+++ b/fern/versions/v2026-01-15/pages/integrating-dafpay/integration.mdx
@@ -13,17 +13,13 @@ In both modes, the DAFpay JavaScript bundle is loaded from Chariot's CDN and the
 
 | Directive    | Add to allowlist                              | Why it's needed                                                                                                                                                            |
 |--------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `script-src` | `https://cdn.givechariot.com`                 | Loads `chariot-connect.umd.js` (and the lightweight `initialize-dafpay.js` loader plus its versioned `chariot-connect-vX.Y.Z.umd.js` bundle) from Chariot's CDN.           |
+| `script-src` | `https://cdn.givechariot.com`                 | Loads `chariot-connect.umd.js` from Chariot's CDN.           |
 | `frame-src`  | `https://secure.dafpay.com`                   | Embeds the DAFpay checkout in a cross-origin iframe. If `frame-src` is not set, browsers fall back to `child-src`, then `default-src`.                                     |
-| `font-src`   | `https://cdn.givechariot.com`                 | The DAFpay web component injects `@font-face` rules into your document referencing Chariot-hosted fonts (e.g., `CircularStd`, `Matter`, `Poppins`).                         |
-| `style-src`  | `'unsafe-inline'` (or a matching nonce/hash)  | The Vue-based web component and Zoid both inject inline `<style>` blocks (font-face declarations and modal overlay styles) into the parent document.                       |
+| `font-src`   | `https://cdn.givechariot.com`                 | The DAFpay web component injects `@font-face` rules into your document referencing Chariot-hosted fonts.                         |
+| `style-src`  | `'unsafe-inline'` (or a matching nonce/hash)  | The web component injects inline `<style>` blocks into the parent document.                       |
 | `img-src`    | `https://cdn.givechariot.com`                 | DAFpay tile and extended button themes reference DAF provider logos and other imagery hosted on Chariot's CDN.                                                             |
 
 The parent page does **not** need to allow `connect-src` for Chariot — all DAFpay API traffic originates inside the iframe (`secure.dafpay.com`), which has its own CSP that we manage.
-
-<Warning title="style-src 'unsafe-inline'">
-The DAFpay web component currently relies on inline `<style>` injection. If your CSP forbids `'unsafe-inline'` and you need to use nonces or hashes, contact Chariot support before integrating — your CSP will block the modal styles even though the script and iframe load successfully.
-</Warning>
 
 ### Example Header
 
@@ -44,26 +40,6 @@ Merge each directive into your existing policy — do not replace your full CSP 
 <Tip title="Meta Tag Limitation">
 If you deliver CSP via a `<meta http-equiv="Content-Security-Policy">` tag instead of an HTTP header, the same directives apply, but `frame-ancestors`, `report-uri`, `report-to`, and `sandbox` are silently ignored from meta tags. Use a response header whenever possible.
 </Tip>
-
-### Staging / Sandbox
-
-If you are testing with a Connect ID that begins with `staging_`, the checkout loads from a different origin and you must also allow:
-
-- `frame-src https://staging.dafpay.com`
-
-(`script-src` for the CDN is the same as production.)
-
-### Permissions-Policy and Passkey Authentication
-
-DAFpay uses WebAuthn (passkeys) for returning-donor authentication inside the checkout iframe. For passkey auth to work in a cross-origin iframe, your page must also delegate the credential permissions to `secure.dafpay.com` via the `Permissions-Policy` response header:
-
-```http
-Permissions-Policy:
-  publickey-credentials-create=(self "https://secure.dafpay.com"),
-  publickey-credentials-get=(self "https://secure.dafpay.com")
-```
-
-Without this delegation, passkey auth will fail inside the iframe and donors will be downgraded to SMS one-time-passcode flows.
 
 ### Troubleshooting
 

--- a/fern/versions/v2026-01-15/pages/integrating-dafpay/integration.mdx
+++ b/fern/versions/v2026-01-15/pages/integrating-dafpay/integration.mdx
@@ -3,6 +3,78 @@ title: Integrating Connect
 hidden: false
 ---
 
+## Content Security Policy
+
+DAFpay is distributed as a cross-origin web component. The button renders inline on your page, but the checkout itself runs in either a cross-origin **iframe** embedded in your page (most desktop browsers, when the viewport supports the modal) or a cross-origin **popup window** at `https://secure.dafpay.com` (mobile devices, Safari, or when the parent viewport is too small for the modal).
+
+In both modes, the DAFpay JavaScript bundle is loaded from Chariot's CDN and the web component injects `@font-face` declarations and inline styles into your page's document. If your site sends a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) header — via either `Content-Security-Policy` or `Content-Security-Policy-Report-Only` — you must allow the directives below or the integration will silently fail to load.
+
+### Required Directives
+
+| Directive    | Add to allowlist                              | Why it's needed                                                                                                                                                            |
+|--------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `script-src` | `https://cdn.givechariot.com`                 | Loads `chariot-connect.umd.js` (and the lightweight `initialize-dafpay.js` loader plus its versioned `chariot-connect-vX.Y.Z.umd.js` bundle) from Chariot's CDN.           |
+| `frame-src`  | `https://secure.dafpay.com`                   | Embeds the DAFpay checkout in a cross-origin iframe. If `frame-src` is not set, browsers fall back to `child-src`, then `default-src`.                                     |
+| `font-src`   | `https://cdn.givechariot.com`                 | The DAFpay web component injects `@font-face` rules into your document referencing Chariot-hosted fonts (e.g., `CircularStd`, `Matter`, `Poppins`).                         |
+| `style-src`  | `'unsafe-inline'` (or a matching nonce/hash)  | The Vue-based web component and Zoid both inject inline `<style>` blocks (font-face declarations and modal overlay styles) into the parent document.                       |
+| `img-src`    | `https://cdn.givechariot.com`                 | DAFpay tile and extended button themes reference DAF provider logos and other imagery hosted on Chariot's CDN.                                                             |
+
+The parent page does **not** need to allow `connect-src` for Chariot — all DAFpay API traffic originates inside the iframe (`secure.dafpay.com`), which has its own CSP that we manage.
+
+<Warning title="style-src 'unsafe-inline'">
+The DAFpay web component currently relies on inline `<style>` injection. If your CSP forbids `'unsafe-inline'` and you need to use nonces or hashes, contact Chariot support before integrating — your CSP will block the modal styles even though the script and iframe load successfully.
+</Warning>
+
+### Example Header
+
+A minimal CSP that permits a DAFpay integration alongside your existing `'self'` policy:
+
+```http
+Content-Security-Policy:
+  default-src 'self';
+  script-src  'self' https://cdn.givechariot.com;
+  frame-src   https://secure.dafpay.com;
+  font-src    'self' https://cdn.givechariot.com;
+  style-src   'self' 'unsafe-inline' https://cdn.givechariot.com;
+  img-src     'self' https://cdn.givechariot.com data:;
+```
+
+Merge each directive into your existing policy — do not replace your full CSP with the example above.
+
+<Tip title="Meta Tag Limitation">
+If you deliver CSP via a `<meta http-equiv="Content-Security-Policy">` tag instead of an HTTP header, the same directives apply, but `frame-ancestors`, `report-uri`, `report-to`, and `sandbox` are silently ignored from meta tags. Use a response header whenever possible.
+</Tip>
+
+### Staging / Sandbox
+
+If you are testing with a Connect ID that begins with `staging_`, the checkout loads from a different origin and you must also allow:
+
+- `frame-src https://staging.dafpay.com`
+
+(`script-src` for the CDN is the same as production.)
+
+### Permissions-Policy and Passkey Authentication
+
+DAFpay uses WebAuthn (passkeys) for returning-donor authentication inside the checkout iframe. For passkey auth to work in a cross-origin iframe, your page must also delegate the credential permissions to `secure.dafpay.com` via the `Permissions-Policy` response header:
+
+```http
+Permissions-Policy:
+  publickey-credentials-create=(self "https://secure.dafpay.com"),
+  publickey-credentials-get=(self "https://secure.dafpay.com")
+```
+
+Without this delegation, passkey auth will fail inside the iframe and donors will be downgraded to SMS one-time-passcode flows.
+
+### Troubleshooting
+
+If the DAFpay button does not render, or clicking it does nothing:
+
+1. Open your browser's developer console. CSP violations are logged as errors prefixed with `Refused to load the script/frame/font/style` and name the directive that blocked the request.
+2. Check the **Network** tab for blocked requests to `cdn.givechariot.com` or `secure.dafpay.com`.
+3. If you ship a `Content-Security-Policy-Report-Only` header alongside your live policy, your reporting endpoint will receive `csp-violation` events naming the affected URLs.
+
+If you cannot relax your CSP — for example because of PCI scope or a vendor security policy — reach out to Chariot support to discuss alternative integration paths.
+
 ## Collecting Form Data
 DAFpay can auto-populate the donor contact fields or your platform can pass donor information directly into the onDonationRequest.
 

--- a/fern/versions/v2026-04-01/pages/integrating-dafpay/integration.mdx
+++ b/fern/versions/v2026-04-01/pages/integrating-dafpay/integration.mdx
@@ -13,17 +13,13 @@ In both modes, the DAFpay JavaScript bundle is loaded from Chariot's CDN and the
 
 | Directive    | Add to allowlist                              | Why it's needed                                                                                                                                                            |
 |--------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `script-src` | `https://cdn.givechariot.com`                 | Loads `chariot-connect.umd.js` (and the lightweight `initialize-dafpay.js` loader plus its versioned `chariot-connect-vX.Y.Z.umd.js` bundle) from Chariot's CDN.           |
+| `script-src` | `https://cdn.givechariot.com`                 | Loads `chariot-connect.umd.js` from Chariot's CDN.           |
 | `frame-src`  | `https://secure.dafpay.com`                   | Embeds the DAFpay checkout in a cross-origin iframe. If `frame-src` is not set, browsers fall back to `child-src`, then `default-src`.                                     |
-| `font-src`   | `https://cdn.givechariot.com`                 | The DAFpay web component injects `@font-face` rules into your document referencing Chariot-hosted fonts (e.g., `CircularStd`, `Matter`, `Poppins`).                         |
-| `style-src`  | `'unsafe-inline'` (or a matching nonce/hash)  | The Vue-based web component and Zoid both inject inline `<style>` blocks (font-face declarations and modal overlay styles) into the parent document.                       |
+| `font-src`   | `https://cdn.givechariot.com`                 | The DAFpay web component injects `@font-face` rules into your document referencing Chariot-hosted fonts.                         |
+| `style-src`  | `'unsafe-inline'` (or a matching nonce/hash)  | The web component injects inline `<style>` blocks into the parent document.                       |
 | `img-src`    | `https://cdn.givechariot.com`                 | DAFpay tile and extended button themes reference DAF provider logos and other imagery hosted on Chariot's CDN.                                                             |
 
 The parent page does **not** need to allow `connect-src` for Chariot — all DAFpay API traffic originates inside the iframe (`secure.dafpay.com`), which has its own CSP that we manage.
-
-<Warning title="style-src 'unsafe-inline'">
-The DAFpay web component currently relies on inline `<style>` injection. If your CSP forbids `'unsafe-inline'` and you need to use nonces or hashes, contact Chariot support before integrating — your CSP will block the modal styles even though the script and iframe load successfully.
-</Warning>
 
 ### Example Header
 
@@ -44,26 +40,6 @@ Merge each directive into your existing policy — do not replace your full CSP 
 <Tip title="Meta Tag Limitation">
 If you deliver CSP via a `<meta http-equiv="Content-Security-Policy">` tag instead of an HTTP header, the same directives apply, but `frame-ancestors`, `report-uri`, `report-to`, and `sandbox` are silently ignored from meta tags. Use a response header whenever possible.
 </Tip>
-
-### Staging / Sandbox
-
-If you are testing with a Connect ID that begins with `staging_`, the checkout loads from a different origin and you must also allow:
-
-- `frame-src https://staging.dafpay.com`
-
-(`script-src` for the CDN is the same as production.)
-
-### Permissions-Policy and Passkey Authentication
-
-DAFpay uses WebAuthn (passkeys) for returning-donor authentication inside the checkout iframe. For passkey auth to work in a cross-origin iframe, your page must also delegate the credential permissions to `secure.dafpay.com` via the `Permissions-Policy` response header:
-
-```http
-Permissions-Policy:
-  publickey-credentials-create=(self "https://secure.dafpay.com"),
-  publickey-credentials-get=(self "https://secure.dafpay.com")
-```
-
-Without this delegation, passkey auth will fail inside the iframe and donors will be downgraded to SMS one-time-passcode flows.
 
 ### Troubleshooting
 

--- a/fern/versions/v2026-04-01/pages/integrating-dafpay/integration.mdx
+++ b/fern/versions/v2026-04-01/pages/integrating-dafpay/integration.mdx
@@ -3,6 +3,78 @@ title: Integrating Connect
 hidden: false
 ---
 
+## Content Security Policy
+
+DAFpay is distributed as a cross-origin web component. The button renders inline on your page, but the checkout itself runs in either a cross-origin **iframe** embedded in your page (most desktop browsers, when the viewport supports the modal) or a cross-origin **popup window** at `https://secure.dafpay.com` (mobile devices, Safari, or when the parent viewport is too small for the modal).
+
+In both modes, the DAFpay JavaScript bundle is loaded from Chariot's CDN and the web component injects `@font-face` declarations and inline styles into your page's document. If your site sends a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) header — via either `Content-Security-Policy` or `Content-Security-Policy-Report-Only` — you must allow the directives below or the integration will silently fail to load.
+
+### Required Directives
+
+| Directive    | Add to allowlist                              | Why it's needed                                                                                                                                                            |
+|--------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `script-src` | `https://cdn.givechariot.com`                 | Loads `chariot-connect.umd.js` (and the lightweight `initialize-dafpay.js` loader plus its versioned `chariot-connect-vX.Y.Z.umd.js` bundle) from Chariot's CDN.           |
+| `frame-src`  | `https://secure.dafpay.com`                   | Embeds the DAFpay checkout in a cross-origin iframe. If `frame-src` is not set, browsers fall back to `child-src`, then `default-src`.                                     |
+| `font-src`   | `https://cdn.givechariot.com`                 | The DAFpay web component injects `@font-face` rules into your document referencing Chariot-hosted fonts (e.g., `CircularStd`, `Matter`, `Poppins`).                         |
+| `style-src`  | `'unsafe-inline'` (or a matching nonce/hash)  | The Vue-based web component and Zoid both inject inline `<style>` blocks (font-face declarations and modal overlay styles) into the parent document.                       |
+| `img-src`    | `https://cdn.givechariot.com`                 | DAFpay tile and extended button themes reference DAF provider logos and other imagery hosted on Chariot's CDN.                                                             |
+
+The parent page does **not** need to allow `connect-src` for Chariot — all DAFpay API traffic originates inside the iframe (`secure.dafpay.com`), which has its own CSP that we manage.
+
+<Warning title="style-src 'unsafe-inline'">
+The DAFpay web component currently relies on inline `<style>` injection. If your CSP forbids `'unsafe-inline'` and you need to use nonces or hashes, contact Chariot support before integrating — your CSP will block the modal styles even though the script and iframe load successfully.
+</Warning>
+
+### Example Header
+
+A minimal CSP that permits a DAFpay integration alongside your existing `'self'` policy:
+
+```http
+Content-Security-Policy:
+  default-src 'self';
+  script-src  'self' https://cdn.givechariot.com;
+  frame-src   https://secure.dafpay.com;
+  font-src    'self' https://cdn.givechariot.com;
+  style-src   'self' 'unsafe-inline' https://cdn.givechariot.com;
+  img-src     'self' https://cdn.givechariot.com data:;
+```
+
+Merge each directive into your existing policy — do not replace your full CSP with the example above.
+
+<Tip title="Meta Tag Limitation">
+If you deliver CSP via a `<meta http-equiv="Content-Security-Policy">` tag instead of an HTTP header, the same directives apply, but `frame-ancestors`, `report-uri`, `report-to`, and `sandbox` are silently ignored from meta tags. Use a response header whenever possible.
+</Tip>
+
+### Staging / Sandbox
+
+If you are testing with a Connect ID that begins with `staging_`, the checkout loads from a different origin and you must also allow:
+
+- `frame-src https://staging.dafpay.com`
+
+(`script-src` for the CDN is the same as production.)
+
+### Permissions-Policy and Passkey Authentication
+
+DAFpay uses WebAuthn (passkeys) for returning-donor authentication inside the checkout iframe. For passkey auth to work in a cross-origin iframe, your page must also delegate the credential permissions to `secure.dafpay.com` via the `Permissions-Policy` response header:
+
+```http
+Permissions-Policy:
+  publickey-credentials-create=(self "https://secure.dafpay.com"),
+  publickey-credentials-get=(self "https://secure.dafpay.com")
+```
+
+Without this delegation, passkey auth will fail inside the iframe and donors will be downgraded to SMS one-time-passcode flows.
+
+### Troubleshooting
+
+If the DAFpay button does not render, or clicking it does nothing:
+
+1. Open your browser's developer console. CSP violations are logged as errors prefixed with `Refused to load the script/frame/font/style` and name the directive that blocked the request.
+2. Check the **Network** tab for blocked requests to `cdn.givechariot.com` or `secure.dafpay.com`.
+3. If you ship a `Content-Security-Policy-Report-Only` header alongside your live policy, your reporting endpoint will receive `csp-violation` events naming the affected URLs.
+
+If you cannot relax your CSP — for example because of PCI scope or a vendor security policy — reach out to Chariot support to discuss alternative integration paths.
+
 ## Collecting Form Data
 DAFpay can auto-populate the donor contact fields or your platform can pass donor information directly into the onDonationRequest.
 


### PR DESCRIPTION
Closes [ENG-319](https://linear.app/givechariot/issue/ENG-319/add-content-security-policy-instructions-to-dafpay-guide-page-on-api).

Adds a top-level `## Content Security Policy` section at the top of the **Integrating Connect** guide (per @drew's link → `/guides/dafpay/integrating-dafpay/integration`), so it's the first thing a partner integrating DAFpay sees on that page. Applied identically to both active doc versions (`v2026-01-15` stable, `v2026-04-01` beta).

## Why

Multiple FP support tickets traced back to strict CSP headers silently breaking the DAFpay integration — the button is rendered but the modal never opens, or fonts never load, or DAF logos in the tile theme fail. There was no public-facing guidance on what to allowlist, so partners had to discover each violation from devtools one at a time.

## What it covers

| Directive | Required value | Why (derived from source) |
|---|---|---|
| `script-src` | `https://cdn.givechariot.com` | UMD bundle + versioned `initialize-dafpay.js` loader (`packages/dafpay/chariot-dafpay-initializer/build.js:11-24`) |
| `frame-src` | `https://secure.dafpay.com` (+ `https://staging.dafpay.com` for `staging_` CIDs) | Cross-origin checkout iframe origin chosen by CID prefix in `packages/dafpay/chariot-zoid/src/dafpay/index.tsx:22-40` |
| `font-src` | `https://cdn.givechariot.com` | `@font-face` rules injected into parent `document.head` from `packages/dafpay/chariot-connect-zoid/src/lib/ChariotConnectLib.ts:36-38` (the `chariotFonts` string references `cdn.givechariot.com/assets/fonts/...`) |
| `style-src` | `'unsafe-inline'` | Same `font.innerHTML = chariotFonts` injection, plus Zoid overlay styles in `packages/dafpay/chariot-zoid/src/components/style.ts` |
| `img-src` | `https://cdn.givechariot.com` | Tile/extended button themes resolve DAF provider logos via `packages/dafpay/chariot-components/src/lib/asset.ts` |

Plus a `Permissions-Policy` block delegating `publickey-credentials-create` / `publickey-credentials-get` to `secure.dafpay.com` — without it, returning-donor passkey auth fails inside the iframe and donors fall back to SMS OTP. The iframe `allow` attribute set by Zoid (`packages/dafpay/chariot-zoid/src/dafpay/index.tsx:67-72`) can only delegate what the parent grants.

The parent page does **not** need `connect-src` for Chariot — all backend traffic happens inside `secure.dafpay.com`, which has its own CSP we manage.

## Surface conversion

The earlier draft on the Linear issue used Starlight-flavored MDX (`:::caution[]`, `:::tip[]`). That's the syntax used by `apps/docs` in `chariot-giving/chariot`, **not** Fern. This PR uses Fern's component syntax (`<Warning title="…">`, `<Tip title="…">`, etc.) to match the rest of the file.

## Open questions left from the Linear thread

1. **Inline vs. dedicated page.** I inlined into `integration.mdx` per @drew's direct link. If you'd rather have a top-level "Content Security Policy" page under DAFpay → Integrating DAFpay (better SEO/findability for FP security teams searching "CSP"), happy to split — would only need a one-line link from `integration.mdx` and an entry under `integrating-dafpay` in both `docs.yml` files.
2. **`report-uri` / `report-to`.** Mentioned in passing in the troubleshooting section. Can expand into its own subsection if useful.
3. **`style-src 'unsafe-inline'` follow-up.** Zoid supports a `nonce` prop, but `chariot-connect-zoid` doesn't surface it to partners, so nonce-based CSP isn't possible today. Worth a separate Linear issue to thread the prop through? I'd be happy to file one if so.

## Review checklist

- [ ] Section placement (top of page vs. elsewhere) is right
- [ ] Wording on the `'unsafe-inline'` caveat — should we soften it / suggest a contact path
- [ ] Want a Permissions-Policy mention this prominent, or move it to a separate page

## Preview

Fern preview will be built on the PR by CI. The change is text-only inside MDX components Fern already uses on this page, so layout impact is limited to the new section.

---

🤖 Drafted by [Auriga](https://auriga.givechariot.com/) at @magaldima's request. See the [Linear issue](https://linear.app/givechariot/issue/ENG-319) for full source-citation breakdown.