### PR TITLE
docs(fdx): add GET /customers/current and organizationId to list accounts

### DIFF
--- a/fern/changelog/05-22-2026.mdx
+++ b/fern/changelog/05-22-2026.mdx
@@ -1,0 +1,13 @@
+## Summary
+
+FDX API updates
+
+### What's new?
+
+- **`GET /customers/current`** — New endpoint to retrieve the authenticated customer's organization-level identity (nonprofit name, EIN, address) directly from the OAuth token, without requiring an account ID.
+- **`organizationId` on list accounts** — The `GET /accounts` response now documents the `organizationId` field, which identifies the organization that owns the accounts. This value is equivalent to the `customerId` returned by `GET /customers/current`.
+
+### Authentication updates
+
+- **Scope documentation** — Clarified that `read:bank_accounts` and `sync:connected_accounts` are mutually exclusive per FDX authorization. A client may hold both scopes, but each authorization must contain exactly one.
+- **Token exchange details** — Added explicit `Authorization: Basic base64(client_id:client_secret)` header format and request body field tables for both token exchange and refresh flows.

--- a/fern/versions/v2026-04-01/pages/fdx/authentication.mdx
+++ b/fern/versions/v2026-04-01/pages/fdx/authentication.mdx
@@ -25,7 +25,14 @@ All requests must include a valid OAuth 2.0 Bearer token in the `Authorization` 
 Authorization: Bearer <access_token>
 ```
 
-Tokens must include the `read:bank_accounts` scope. Requests without a valid token receive a `401 Unauthorized` response.
+Tokens must include exactly one of the following scopes — they are mutually exclusive per authorization. An authorization containing both will be rejected.
+
+| Scope | Description |
+|-------|-------------|
+| `read:bank_accounts` | Read access to bank account data |
+| `sync:connected_accounts` | Sync access to connected account data |
+
+A client may hold both scopes, but each FDX authorization must contain exactly one. Requests without a valid token receive a `401 Unauthorized` response.
 
 ## Token Exchange
 
@@ -68,17 +75,26 @@ After the user authorizes, the browser redirects to your `redirect_uri` with an 
 
 ### 2. Exchange code for token
 
-Exchange the authorization code for an access token and refresh token:
+Exchange the authorization code for an access token and refresh token.
 
-```bash
-curl -X POST https://api.givechariot.com/auth/oauth/token \
-  -u "<client_id>:<client_secret>" \
-  -d "grant_type=authorization_code" \
-  -d "code=<authorization_code>" \
-  -d "redirect_uri=<redirect_uri>"
+`POST https://api.givechariot.com/auth/oauth/token`
+
+**Header** — authenticate with HTTP Basic using your client credentials. Requests without this header will be rejected with 403 Unauthorized.
+
+```
+Authorization: Basic base64(client_id:client_secret)
 ```
 
-The response includes an `access_token` and `refresh_token`:
+**Body** (`application/x-www-form-urlencoded`):
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `grant_type` | Yes | `authorization_code` |
+| `code` | Yes | The authorization code from step 1 |
+| `redirect_uri` | Yes | Must match the URI used in step 1 |
+| `code_verifier` | No | PKCE code verifier, if PKCE was used |
+
+**Response**:
 
 ```json
 {
@@ -91,14 +107,22 @@ The response includes an `access_token` and `refresh_token`:
 
 ### 3. Refresh token
 
-When the access token expires, use the refresh token to obtain a new one:
+When the access token expires, use the refresh token to obtain a new one.
 
-```bash
-curl -X POST https://api.givechariot.com/auth/oauth/token \
-  -u "<client_id>:<client_secret>" \
-  -d "grant_type=refresh_token" \
-  -d "refresh_token=<refresh_token>"
+`POST https://api.givechariot.com/auth/oauth/token`
+
+**Header** — authenticate with HTTP Basic using your client credentials. Requests without this header will be rejected with 403 Unauthorized.
+
 ```
+Authorization: Basic base64(client_id:client_secret)
+```
+
+**Body** (`application/x-www-form-urlencoded`):
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `grant_type` | Yes | `refresh_token` |
+| `refresh_token` | Yes | The refresh token from the original token exchange |
 
 ## IP Whitelisting
 

--- a/specs/fdx-v6.yaml
+++ b/specs/fdx-v6.yaml
@@ -283,60 +283,11 @@ components:
   securitySchemes:
     oauth2:
       type: oauth2
-      description: >
+      description: >-
         OAuth 2.0 Bearer token. A client may hold both scopes, but each
         FDX authorization must contain exactly one — they are mutually
         exclusive per authorization. An authorization containing both will
-        be rejected.
-
-
-        ## Authentication
-
-
-        ### 1. Authorize
-
-        Redirect the user to the authorization URL with your `client_id`,
-        `redirect_uri`, `scope`, and `state`. The user grants consent and is
-        redirected back with an authorization `code`.
-
-
-        ### 2. Exchange code for token
-
-        `POST https://api.givechariot.com/auth/oauth/token`
-
-
-        **Header** — authenticate with HTTP Basic using your client credentials.
-        Requests without this header will be rejected with 403 Unauthorized.
-
-        `Authorization: Basic base64(client_id:client_secret)`
-
-
-        **Body** (`application/x-www-form-urlencoded`):
-
-        | Field | Required | Description |
-        |-------|----------|-------------|
-        | `grant_type` | Yes | `authorization_code` |
-        | `code` | Yes | The authorization code from step 1 |
-        | `code_verifier` | No | PKCE code verifier, if PKCE was used |
-
-
-        ### 3. Refresh token
-
-        `POST https://api.givechariot.com/auth/oauth/token`
-
-
-        **Header** — authenticate with HTTP Basic using your client credentials.
-        Requests without this header will be rejected with 403 Unauthorized.
-
-        `Authorization: Basic base64(client_id:client_secret)`
-
-
-        **Body** (`application/x-www-form-urlencoded`):
-
-        | Field | Required | Description |
-        |-------|----------|-------------|
-        | `grant_type` | Yes | `refresh_token` |
-        | `refresh_token` | Yes | The refresh token from the original token exchange |
+        be rejected. See the Authentication page for token exchange details.
       flows:
         authorizationCode:
           authorizationUrl: https://dashboard.givechariot.com/oauth/authorize

--- a/specs/fdx-v6.yaml
+++ b/specs/fdx-v6.yaml
@@ -193,6 +193,30 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /customers/current:
+    get:
+      summary: Get current customer
+      description: >-
+        Get the organization-level identity for the current authenticated
+        customer. Returns org-level data (nonprofit name, EIN, address).
+        Individual control-person data is excluded because consent is org-level.
+      operationId: getCurrentCustomer
+      tags:
+        - Customers
+      responses:
+        "200":
+          description: The current authenticated customer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Customer"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /accounts/{id}/customers:
     get:
       summary: List account customers
@@ -524,6 +548,12 @@ components:
       required:
         - accounts
       properties:
+        organizationId:
+          type: string
+          format: uuid
+          description: >-
+            The organization that owns the accounts. Equivalent to the
+            customerId returned by GET /customers/current.
         page:
           $ref: "#/components/schemas/Page"
         accounts:

--- a/specs/fdx-v6.yaml
+++ b/specs/fdx-v6.yaml
@@ -283,13 +283,67 @@ components:
   securitySchemes:
     oauth2:
       type: oauth2
-      description: OAuth 2.0 Bearer token with the `read:bank_accounts` scope
+      description: >
+        OAuth 2.0 Bearer token. A client may hold both scopes, but each
+        FDX authorization must contain exactly one — they are mutually
+        exclusive per authorization. An authorization containing both will
+        be rejected.
+
+
+        ## Authentication
+
+
+        ### 1. Authorize
+
+        Redirect the user to the authorization URL with your `client_id`,
+        `redirect_uri`, `scope`, and `state`. The user grants consent and is
+        redirected back with an authorization `code`.
+
+
+        ### 2. Exchange code for token
+
+        `POST https://api.givechariot.com/auth/oauth/token`
+
+
+        **Header** — authenticate with HTTP Basic using your client credentials.
+        Requests without this header will be rejected with 403 Unauthorized.
+
+        `Authorization: Basic base64(client_id:client_secret)`
+
+
+        **Body** (`application/x-www-form-urlencoded`):
+
+        | Field | Required | Description |
+        |-------|----------|-------------|
+        | `grant_type` | Yes | `authorization_code` |
+        | `code` | Yes | The authorization code from step 1 |
+        | `code_verifier` | No | PKCE code verifier, if PKCE was used |
+
+
+        ### 3. Refresh token
+
+        `POST https://api.givechariot.com/auth/oauth/token`
+
+
+        **Header** — authenticate with HTTP Basic using your client credentials.
+        Requests without this header will be rejected with 403 Unauthorized.
+
+        `Authorization: Basic base64(client_id:client_secret)`
+
+
+        **Body** (`application/x-www-form-urlencoded`):
+
+        | Field | Required | Description |
+        |-------|----------|-------------|
+        | `grant_type` | Yes | `refresh_token` |
+        | `refresh_token` | Yes | The refresh token from the original token exchange |
       flows:
         authorizationCode:
           authorizationUrl: https://dashboard.givechariot.com/oauth/authorize
           tokenUrl: https://api.givechariot.com/auth/oauth/token
           scopes:
             "read:bank_accounts": Read access to bank account data
+            "sync:connected_accounts": Sync access to connected account data
 
   parameters:
     AccountId:


### PR DESCRIPTION
Add the new FDX /customers/current endpoint for retrieving the authenticated customer's org-level identity. Document the organizationId field on ListAccountsResponse and note its equivalence to customerId.