### PR TITLE
docs(disbursements): Document Idempotency-Key Header and idempotency_key Query Filter

### DIFF
--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2196,7 +2196,7 @@ paths:
         All disbursements in the request will be created together. If any disbursement fails validation,
         the entire request will fail and no disbursements will be created.
 
-        **Note:** Disbursements created through this endpoint cannot be looked up via `GET /v1/disbursements?idempotency_key=...`. The `idempotency_key` field on the returned disbursements will be `null`.
+        **Note:** Disbursements created through this endpoint cannot be looked up via `GET /v1/disbursements?idempotency_key=...`. The `idempotency_key` field on the returned disbursements will be `null`. If you have a unique key per disbursement, create them one at a time via `POST /v1/disbursements` with an `Idempotency-Key` header so each row remains queryable.
       operationId: bulkCreateDisbursements
       tags:
         - disbursements

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2099,7 +2099,7 @@ paths:
           description: |-
             A client-generated identifier for the request. Replays with the same key return `409 Conflict`. The successfully created disbursement can later be located via `GET /v1/disbursements?idempotency_key=...`.
 
-            We recommend supplying your own unique identifier for the disbursement (e.g. your internal grant/transaction ID) so you can later look the disbursement up by an ID you already track.
+            We recommend supplying your own unique identifier for the disbursement so you can later look it up by an ID you already track.
           required: false
           schema:
             type: string

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2093,6 +2093,14 @@ paths:
         - disbursements
       security:
         - bearerAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          description: |-
+            A client-generated identifier for the request. Replays with the same key return `409 Conflict`. The successfully created disbursement can later be located via `GET /v1/disbursements?idempotency_key=...`.
+          required: false
+          schema:
+            type: string
       requestBody:
         $ref: "#/components/requestBodies/CreateDisbursementRequest"
       responses:
@@ -2159,6 +2167,14 @@ paths:
           schema:
             type: string
             example: "organization"
+        - name: idempotency_key
+          in: query
+          description: |-
+            Filter to the disbursement created with this exact `Idempotency-Key` header on `POST /v1/disbursements`. Useful for recovering the result of a create request when the response was lost (e.g. network timeout). Returns at most one disbursement. Disbursements created via `POST /v1/disbursements/bulk` cannot be looked up this way.
+          required: false
+          schema:
+            type: string
+            example: "8e91b2f3-d7c4-4a59-9a91-72a40b1f2c3d"
       responses:
         "200":
           $ref: "#/components/responses/ListDisbursementsResponse"

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2099,7 +2099,7 @@ paths:
           description: |-
             A client-generated identifier for the request. Replays with the same key return `409 Conflict`. The successfully created disbursement can later be located via `GET /v1/disbursements?idempotency_key=...`.
 
-            We recommend supplying your own unique identifier for the disbursement so you can later look it up by an ID you already track.
+            We recommend supplying your own unique identifier for the disbursement in your system, so you can later look it up by an ID you already track.
           required: false
           schema:
             type: string

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2195,6 +2195,8 @@ paths:
 
         All disbursements in the request will be created together. If any disbursement fails validation,
         the entire request will fail and no disbursements will be created.
+
+        **Note:** Disbursements created through this endpoint cannot be looked up via `GET /v1/disbursements?idempotency_key=...`. The `idempotency_key` field on the returned disbursements will be `null`. If you need to recover individual disbursements by idempotency key, create them one at a time via `POST /v1/disbursements`.
       operationId: bulkCreateDisbursements
       tags:
         - disbursements

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2196,7 +2196,7 @@ paths:
         All disbursements in the request will be created together. If any disbursement fails validation,
         the entire request will fail and no disbursements will be created.
 
-        **Note:** Disbursements created through this endpoint cannot be looked up via `GET /v1/disbursements?idempotency_key=...`. The `idempotency_key` field on the returned disbursements will be `null`. If you need to recover individual disbursements by idempotency key, create them one at a time via `POST /v1/disbursements`.
+        **Note:** Disbursements created through this endpoint cannot be looked up via `GET /v1/disbursements?idempotency_key=...`. The `idempotency_key` field on the returned disbursements will be `null`.
       operationId: bulkCreateDisbursements
       tags:
         - disbursements

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2098,6 +2098,8 @@ paths:
           in: header
           description: |-
             A client-generated identifier for the request. Replays with the same key return `409 Conflict`. The successfully created disbursement can later be located via `GET /v1/disbursements?idempotency_key=...`.
+
+            We recommend supplying your own unique identifier for the disbursement (e.g. your internal grant/transaction ID) so you can later look the disbursement up by an ID you already track.
           required: false
           schema:
             type: string
@@ -2196,7 +2198,7 @@ paths:
         All disbursements in the request will be created together. If any disbursement fails validation,
         the entire request will fail and no disbursements will be created.
 
-        **Note:** Disbursements created through this endpoint cannot be looked up via `GET /v1/disbursements?idempotency_key=...`. The `idempotency_key` field on the returned disbursements will be `null`. If you have a unique key per disbursement, create them one at a time via `POST /v1/disbursements` with an `Idempotency-Key` header so each row remains queryable.
+        **Note:** Disbursements created through this endpoint cannot be looked up via `GET /v1/disbursements?idempotency_key=...`. The `idempotency_key` field on the returned disbursements will be `null`.
       operationId: bulkCreateDisbursements
       tags:
         - disbursements

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -5642,6 +5642,12 @@ components:
           description: The list of transactions for the disbursement
           items:
             $ref: "#/components/schemas/Transaction"
+        idempotency_key:
+          type: string
+          description: |-
+            The `Idempotency-Key` header value the disbursement was created with. Only set for single-create disbursements; bulk-created disbursements omit this field.
+          example: "8e91b2f3-d7c4-4a59-9a91-72a40b1f2c3d"
+          readOnly: true
     DisbursementStatus:
       type: string
       description: |-


### PR DESCRIPTION
## Summary
- Document the existing `Idempotency-Key` request header on `POST /v1/disbursements`
- Add the new `idempotency_key` query parameter on `GET /v1/disbursements`, which returns the disbursement created with that key (single-create only — bulk creates are not queryable this way)

Paired with the backend change in chariot2.

## Test plan
- [ ] `fern check` (or whatever lint runs in CI) passes on the spec