### PR TITLE
docs(dafpay): add OAuth Integration (for DAFs) guide section

### DIFF
--- a/fern/versions/v2026-04-01/docs.yml
+++ b/fern/versions/v2026-04-01/docs.yml
@@ -86,6 +86,9 @@ navigation:
               - page: API Endpoints
                 slug: api-endpoints
                 path: ./pages/oauth/api-endpoints.mdx
+              - page: Security Best Practices
+                slug: security
+                path: ./pages/oauth/security.mdx
               - page: Integration Checklist
                 slug: integration-checklist
                 path: ./pages/oauth/integration-checklist.mdx

--- a/fern/versions/v2026-04-01/docs.yml
+++ b/fern/versions/v2026-04-01/docs.yml
@@ -74,6 +74,21 @@ navigation:
               - page: FAQ
                 slug: faq
                 path: ./pages/donor-accounts/faq.mdx
+          - section: OAuth Integration (for DAFs)
+            slug: oauth
+            contents:
+              - page: Overview
+                slug: overview
+                path: ./pages/oauth/overview.mdx
+              - page: OAuth & Token Requirements
+                slug: oauth-requirements
+                path: ./pages/oauth/oauth-requirements.mdx
+              - page: API Endpoints
+                slug: api-endpoints
+                path: ./pages/oauth/api-endpoints.mdx
+              - page: Integration Checklist
+                slug: integration-checklist
+                path: ./pages/oauth/integration-checklist.mdx
       - section: Disbursements
         slug: disbursements
         contents:

--- a/fern/versions/v2026-04-01/pages/oauth/api-endpoints.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/api-endpoints.mdx
@@ -4,14 +4,24 @@ subtitle: "The resource APIs Chariot calls — authorized by the donor's access 
 hidden: false
 ---
 
+## Capabilities, not contracts
+
+Chariot does not require you to implement an exact API specification. What Chariot requires is a set of **capabilities** — the data and operations the donation flow depends on. The endpoint paths, names, and field shapes on this page are **recommended shapes**: if you have existing APIs with different paths or field names, share your documentation and Chariot will adapt during the integration build.
+
+| Capability | Requirement |
+|---|---|
+| [Get Current Donor](#1-get-current-donor) | Required |
+| [List Funds](#2-list-funds) with grantable balances | Required |
+| [Search Organizations](#3-search-organizations) | Only if your grant API can't accept an EIN directly |
+| [Create Grant](#4-create-grant) with idempotency | Required |
+| [Get Grant Status](#5-get-grant-status) | Required |
+
 ## Conventions
 
-- All endpoints are served over **TLS 1.2+** and protected by **Bearer access tokens** issued by your authorization server. Validate the token's signature (or introspect it), expiry, and scope on every request.
+- All endpoints are served over **TLS 1.2+** and authorized by **Bearer access tokens** issued by your authorization server — see [Security Best Practices](/guides/dafpay/oauth/security#token-security).
 - All requests and responses are `application/json`.
 - All monetary amounts are **integer cents in USD** (e.g., `25000` = $250.00) unless we agree otherwise during onboarding.
 - Error responses should use conventional HTTP status codes (`401` invalid/expired token, `403` insufficient scope, `404` not found, `422` validation, `429` rate limited). RFC 7807 Problem Details bodies are recommended but not required.
-
-Endpoint paths below are **recommended shapes**. If you have existing APIs with different paths or field names, that's fine — share your documentation and Chariot will adapt during the integration build. What matters is that the five capabilities below exist.
 
 ---
 
@@ -75,7 +85,7 @@ Authorization: Bearer {access_token}
 
 ## 3. Search Organizations
 
-Resolves a nonprofit to your internal organization ID so Chariot can create the grant. Chariot will always query by **EIN**.
+**Only required if your systems don't uniquely identify nonprofits by EIN.** Chariot identifies every nonprofit by its EIN. If your [Create Grant](#4-create-grant) endpoint can accept an EIN directly, skip this endpoint — Chariot will supply the EIN in the grant request. Otherwise, expose a lookup that resolves an EIN to your internal organization ID:
 
 ```
 GET /organizations?ein=133441466
@@ -134,9 +144,14 @@ Content-Type: application/json
 }
 ```
 
-Requirements:
+If you don't implement [Search Organizations](#3-search-organizations), accept an `ein` field here in place of `organization_id`.
 
-- **Idempotency.** Honor the `Idempotency-Key` header (or treat a repeated `note` Chariot ID as a duplicate). Network retries must never create duplicate grants.
+<Warning title="Idempotency is required">
+Create Grant **must be idempotent**. Honor the `Idempotency-Key` header: a retried request with the same key must return the original grant, never create a second one. Chariot retries on network failures and timeouts, and a duplicate grant means a donor gives twice — this is the single most important behavior on this page.
+</Warning>
+
+Additional requirements:
+
 - **Chariot ID on the grant letter.** The Chariot Grant Request ID passed in `note` must appear on the grant letter / remittance advice sent to the nonprofit. This is how nonprofits and Chariot reconcile incoming grants — it is essential to the DAFpay experience.
 - `anonymous: true` means the donor's name and contact details are withheld from the nonprofit, per your standard anonymity handling.
 
@@ -173,14 +188,11 @@ Map your internal statuses onto this set:
 | `rejected` | Declined — include a donor-safe reason in `status_description` |
 | `canceled` | Canceled by the donor or by you before payment |
 
-<Tip title="Webhooks (optional, recommended)">
-Instead of (or in addition to) polling, you can push status changes to a Chariot webhook URL provided during onboarding. A simple `POST` with `{ "grant_id": "...", "status": "paid" }` signed with a shared secret is sufficient. Webhooks get donors and nonprofits faster status visibility and reduce load on your API.
-</Tip>
-
 ---
 
-## Rate limits and availability
+## Performance and availability
 
-- Support at least **10 requests/second** from Chariot's IPs per environment, or share your limits so we can configure client-side throttling.
-- Chariot calls originate from a static IP range (provided during onboarding) if you require allowlisting.
-- Target **99.9% availability** on these endpoints — an outage during a donation attempt means an abandoned gift.
+- Target **99.9% availability** on these endpoints (99.5% minimum), measured monthly and excluding maintenance windows announced to Chariot in advance. An outage during a donation attempt means an abandoned gift.
+- Keep response times under **~3.5 seconds** (ideally P95 under 2 seconds) — donors are waiting on these calls inside the checkout flow.
+- Support at least **10 requests/second** from Chariot per environment, or share your limits so we can configure client-side throttling.
+- Chariot's calls originate from a static IP range (provided during onboarding) if you require allowlisting — see [Security Best Practices](/guides/dafpay/oauth/security#ip-allowlisting).

--- a/fern/versions/v2026-04-01/pages/oauth/api-endpoints.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/api-endpoints.mdx
@@ -1,0 +1,186 @@
+---
+title: "API Endpoints"
+subtitle: "The resource APIs Chariot calls — authorized by the donor's access token — to power the donation flow."
+hidden: false
+---
+
+## Conventions
+
+- All endpoints are served over **TLS 1.2+** and protected by **Bearer access tokens** issued by your authorization server. Validate the token's signature (or introspect it), expiry, and scope on every request.
+- All requests and responses are `application/json`.
+- All monetary amounts are **integer cents in USD** (e.g., `25000` = $250.00) unless we agree otherwise during onboarding.
+- Error responses should use conventional HTTP status codes (`401` invalid/expired token, `403` insufficient scope, `404` not found, `422` validation, `429` rate limited). RFC 7807 Problem Details bodies are recommended but not required.
+
+Endpoint paths below are **recommended shapes**. If you have existing APIs with different paths or field names, that's fine — share your documentation and Chariot will adapt during the integration build. What matters is that the five capabilities below exist.
+
+---
+
+## 1. Get Current Donor
+
+Returns the authenticated donor's profile. Chariot displays this in the grant review pane and uses it to populate the donor's DAFpay profile.
+
+```
+GET /customers/current
+Authorization: Bearer {access_token}
+```
+
+```json
+{
+  "id": "usr_8f2k1",
+  "first_name": "Dana",
+  "last_name": "Levy",
+  "email": "dana@example.com",
+  "phone": "+12125550123",
+  "address": {
+    "line1": "350 5th Ave",
+    "line2": "Suite 7200",
+    "city": "New York",
+    "state": "NY",
+    "zip": "10118"
+  }
+}
+```
+
+`id` should equal (or be deterministically linked to) the `sub` claim in your ID Token.
+
+---
+
+## 2. List Funds
+
+Returns the giving funds the donor is authorized to grant from. If the donor has advisory privileges on multiple funds, return all of them — DAFpay lets the donor choose.
+
+```
+GET /funds
+Authorization: Bearer {access_token}
+```
+
+```json
+{
+  "funds": [
+    {
+      "id": "fund_a91x",
+      "name": "The Levy Family Charitable Fund",
+      "grantable_balance": 18250000,
+      "currency": "USD"
+    }
+  ]
+}
+```
+
+<Note>
+`grantable_balance` is the amount **available to grant right now** — net of pending grants and any holds — not the total fund value. This is what DAFpay displays to the donor and uses to prevent over-balance grant submissions.
+</Note>
+
+---
+
+## 3. Search Organizations
+
+Resolves a nonprofit to your internal organization ID so Chariot can create the grant. Chariot will always query by **EIN**.
+
+```
+GET /organizations?ein=133441466
+Authorization: Bearer {access_token}
+```
+
+```json
+{
+  "organizations": [
+    {
+      "id": "org_77fq",
+      "ein": "13-3441466",
+      "name": "Example Charity Inc.",
+      "address": {
+        "line1": "123 Main St",
+        "city": "Brooklyn",
+        "state": "NY",
+        "zip": "11201"
+      }
+    }
+  ]
+}
+```
+
+If the organization is not yet in your system, either return an empty list (Chariot will surface a fallback to the donor) or — preferably — support on-demand creation from IRS records, which maximizes donation completion.
+
+---
+
+## 4. Create Grant
+
+Creates a grant recommendation on the donor's behalf. The grant enters **your normal review and disbursement pipeline** — Chariot does not bypass your compliance process.
+
+```
+POST /grants
+Authorization: Bearer {access_token}
+Idempotency-Key: {chariot_grant_request_id}
+Content-Type: application/json
+```
+
+```json
+{
+  "fund_id": "fund_a91x",
+  "organization_id": "org_77fq",
+  "amount": 25000,
+  "purpose": "Wherever needed most",
+  "note": "DAFpay Grant Request: grant_req_01jpjenf5q6cawy43yxfcrxhct",
+  "anonymous": false
+}
+```
+
+```json
+{
+  "id": "grant_3kd02",
+  "status": "pending",
+  "created_at": "2026-06-10T14:30:00Z"
+}
+```
+
+Requirements:
+
+- **Idempotency.** Honor the `Idempotency-Key` header (or treat a repeated `note` Chariot ID as a duplicate). Network retries must never create duplicate grants.
+- **Chariot ID on the grant letter.** The Chariot Grant Request ID passed in `note` must appear on the grant letter / remittance advice sent to the nonprofit. This is how nonprofits and Chariot reconcile incoming grants — it is essential to the DAFpay experience.
+- `anonymous: true` means the donor's name and contact details are withheld from the nonprofit, per your standard anonymity handling.
+
+---
+
+## 5. Get Grant Status
+
+Chariot polls this endpoint to keep donors and nonprofits informed of grant progress.
+
+```
+GET /grants/{grant_id}
+Authorization: Bearer {access_token}
+```
+
+```json
+{
+  "id": "grant_3kd02",
+  "status": "approved",
+  "status_description": null,
+  "created_at": "2026-06-10T14:30:00Z",
+  "updated_at": "2026-06-11T09:12:00Z"
+}
+```
+
+### Status values
+
+Map your internal statuses onto this set:
+
+| Status | Meaning |
+|---|---|
+| `pending` | Received, awaiting review |
+| `approved` | Approved, payment not yet sent |
+| `paid` | Payment sent to the nonprofit |
+| `rejected` | Declined — include a donor-safe reason in `status_description` |
+| `canceled` | Canceled by the donor or by you before payment |
+
+<Tip title="Webhooks (optional, recommended)">
+Instead of (or in addition to) polling, you can push status changes to a Chariot webhook URL provided during onboarding. A simple `POST` with `{ "grant_id": "...", "status": "paid" }` signed with a shared secret is sufficient. Webhooks get donors and nonprofits faster status visibility and reduce load on your API.
+</Tip>
+
+---
+
+## Rate limits and availability
+
+- Support at least **10 requests/second** from Chariot's IPs per environment, or share your limits so we can configure client-side throttling.
+- Chariot calls originate from a static IP range (provided during onboarding) if you require allowlisting.
+- Target **99.9% availability** on these endpoints — an outage during a donation attempt means an abandoned gift.

--- a/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
@@ -14,7 +14,7 @@ hidden: false
 * [ ]  Authorization Code flow with PKCE (S256) and `state` round-trip
 * [ ]  Scopes: `openid profile email offline_access` (plus any custom scopes you require)
 * [ ]  ID Token with stable `sub` and `email` claims
-* [ ]  **Refresh tokens valid ≥ 12 months (recommended: until revoked) — see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime)**
+* [ ]  Long-lived refresh tokens — ≥ 12 months strongly recommended, ideally until revoked; see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime)
 * [ ]  Error redirects on cancel/failure (`error`, `error_description`)
 * [ ]  Token revocation endpoint (recommended)
 
@@ -61,7 +61,7 @@ Before launch, Chariot runs a certification pass against your sandbox:
 
 1. **Auth flows** — happy path, donor cancellation, error redirects, mobile web
 2. **Token lifecycle** — refresh after access-token expiry; rotation grace window (if rotating); behavior after revocation (`invalid_grant`)
-3. **Connection persistence** — refresh succeeds after a simulated dormancy period; this is a launch blocker if refresh tokens expire early
+3. **Connection persistence** — refresh succeeds after a simulated dormancy period, verified against your stated refresh-token policy
 4. **Grant lifecycle** — create, duplicate-submission idempotency, status polling/webhooks, rejection with `status_description`
 5. **Edge cases** — multi-fund donors, insufficient balance, unknown EIN, expired access token mid-flow
 

--- a/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
@@ -14,7 +14,7 @@ hidden: false
 * [ ]  Authorization Code flow with PKCE (S256) and `state` round-trip
 * [ ]  Scopes: `openid profile email offline_access` (plus any custom scopes you require)
 * [ ]  ID Token with stable `sub` and `email` claims
-* [ ]  Long-lived refresh tokens — ≥ 12 months strongly recommended, ideally until revoked; see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime)
+* [ ]  Refresh tokens rotated with each use (preferred) or expiring after 13+ months — see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime)
 * [ ]  Error redirects on cancel/failure (`error`, `error_description`)
 * [ ]  Token revocation endpoint (recommended)
 
@@ -87,9 +87,9 @@ No. In the OAuth model, grants are created directly in your system via your Crea
 
 Yes — but a given donor connection uses one model. Most DAFs choose one; OAuth is the better donor experience if you can support it.
 
-**What happens if a donor's refresh token is revoked?**
+**What happens if a donor's refresh token expires or is revoked?**
 
-On their next donation, DAFpay prompts them to re-link your DAF — they go through your login flow once more, and a fresh long-lived connection is established. Their DAFpay account, history, and Donor Account are unaffected.
+On their next donation, DAFpay prompts them to re-link your DAF — they go through your login flow once more, and a fresh connection is established. Their DAFpay account, history, and Donor Account are unaffected. For expiry, this is the expected reauthorization path; rotation-on-use keeps active donors connected without it.
 
 **Do you support FDX?**
 

--- a/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
@@ -84,7 +84,7 @@ No. In the OAuth model, grants are created directly in your system via your Crea
 
 **Can we support both integrations?**
 
-Yes — but a given donor connection uses one model. Most DAFs choose one; OAuth is the better donor experience if you can support it.
+No — only one integration is supported per DAF.
 
 **What happens if a donor's refresh token expires or is revoked?**
 

--- a/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
@@ -1,0 +1,96 @@
+---
+title: "Integration Checklist"
+subtitle: "Everything required to go from kickoff to live, and how the certification process works."
+hidden: false
+---
+
+## Build checklist
+
+### Authorization server
+
+* [ ]  OAuth 2.0 / OIDC authorization server reachable at a public issuer URL (Okta, Auth0, Cognito, or custom)
+* [ ]  Hosted login page that renders at popup dimensions (~460×720) and on mobile web
+* [ ]  Confidential client registered for Chariot with staging and production redirect URIs
+* [ ]  Authorization Code flow with PKCE (S256) and `state` round-trip
+* [ ]  Scopes: `openid profile email offline_access` (plus any custom scopes you require)
+* [ ]  ID Token with stable `sub` and `email` claims
+* [ ]  **Refresh tokens valid ≥ 12 months (recommended: until revoked) — see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime)**
+* [ ]  Error redirects on cancel/failure (`error`, `error_description`)
+* [ ]  Token revocation endpoint (recommended)
+
+### Resource APIs
+
+* [ ]  Get Current Donor
+* [ ]  List Funds (with **grantable** balances)
+* [ ]  Search Organizations by EIN
+* [ ]  Create Grant — idempotent, with the Chariot ID carried onto the grant letter
+* [ ]  Get Grant Status (and/or status webhooks)
+* [ ]  Bearer token validation on every endpoint
+
+### Environments
+
+* [ ]  Sandbox/staging environment mirroring production behavior
+* [ ]  At least 2 test donor accounts (including one with multiple funds)
+* [ ]  A test fund with a small balance (for over-balance rejection testing)
+
+## Exchange of information
+
+**You send Chariot** (via the secure channel we provide — never email secrets):
+
+| Item | |
+|---|---|
+| `ISSUER_BASE_URL` | OIDC issuer, ideally with `/.well-known/openid-configuration` |
+| `client_id` / `client_secret` | Per environment |
+| API base URLs + docs | For the five resource endpoints |
+| Refresh token policy | Lifetime, idle timeout, rotation on/off |
+| Sandbox credentials | Test donor logins |
+| Technical contact | For integration support and incident escalation |
+
+**Chariot sends you:**
+
+| Item | |
+|---|---|
+| Redirect URIs | Staging and production callback URLs |
+| Webhook URL + signing secret | If you implement status webhooks |
+| Static IP range | If you require allowlisting |
+| Integration contact | Your dedicated Chariot engineer |
+
+## Certification
+
+Before launch, Chariot runs a certification pass against your sandbox:
+
+1. **Auth flows** — happy path, donor cancellation, error redirects, mobile web
+2. **Token lifecycle** — refresh after access-token expiry; rotation grace window (if rotating); behavior after revocation (`invalid_grant`)
+3. **Connection persistence** — refresh succeeds after a simulated dormancy period; this is a launch blocker if refresh tokens expire early
+4. **Grant lifecycle** — create, duplicate-submission idempotency, status polling/webhooks, rejection with `status_description`
+5. **Edge cases** — multi-fund donors, insufficient balance, unknown EIN, expired access token mid-flow
+
+Once certified, we launch your DAF in DAFpay production behind a flag, run a small set of live test grants together, then enable you for all donors.
+
+## Timeline
+
+| Phase | Owner | Typical duration |
+|---|---|---|
+| Kickoff & credential exchange | Both | 1–3 days |
+| Your build (if using Okta/Auth0 + existing APIs) | You | 3–5 days |
+| Your build (from scratch) | You | 4–8 weeks |
+| Chariot integration build & certification | Chariot | ~2 weeks |
+| Production launch & live verification | Both | 2–3 days |
+
+## FAQ
+
+**Do grants still go through the Donor Accounts decisioning API?**
+
+No. In the OAuth model, grants are created directly in your system via your Create Grant API and flow through your normal internal review pipeline. The [Donor Accounts](/guides/dafpay/donor-accounts/overview) decisioning API is for DAFs without their own APIs.
+
+**Can we support both integrations?**
+
+Yes — but a given donor connection uses one model. Most DAFs choose one; OAuth is the better donor experience if you can support it.
+
+**What happens if a donor's refresh token is revoked?**
+
+On their next donation, DAFpay prompts them to re-link your DAF — they go through your login flow once more, and a fresh long-lived connection is established. Their DAFpay account, history, and Donor Account are unaffected.
+
+**Do you support FDX?**
+
+The endpoint shapes in this guide are intentionally simpler than full FDX, scoped to what a DAF donation flow needs. If you already expose FDX-aligned endpoints, share your documentation — Chariot can adapt to FDX resource shapes during the integration build.

--- a/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/integration-checklist.mdx
@@ -11,10 +11,11 @@ hidden: false
 * [ ]  OAuth 2.0 / OIDC authorization server reachable at a public issuer URL (Okta, Auth0, Cognito, or custom)
 * [ ]  Hosted login page that renders at popup dimensions (~460×720) and on mobile web
 * [ ]  Confidential client registered for Chariot with staging and production redirect URIs
-* [ ]  Authorization Code flow with PKCE (S256) and `state` round-trip
+* [ ]  Authorization Code flow with `state` round-trip (PKCE recommended — see [Security Best Practices](/guides/dafpay/oauth/security#pkce))
 * [ ]  Scopes: `openid profile email offline_access` (plus any custom scopes you require)
+* [ ]  Tokens scoped to DAF granting only — never to investment, banking, or brokerage systems (see [Scope of access](/guides/dafpay/oauth/security#scope-of-access))
 * [ ]  ID Token with stable `sub` and `email` claims
-* [ ]  Long-lived refresh tokens — ≥ 12 months strongly recommended, ideally until revoked; see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime)
+* [ ]  Long-lived refresh tokens — 13+ months (or rotating with no fixed expiry) strongly recommended; see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime)
 * [ ]  Error redirects on cancel/failure (`error`, `error_description`)
 * [ ]  Token revocation endpoint (recommended)
 
@@ -22,10 +23,9 @@ hidden: false
 
 * [ ]  Get Current Donor
 * [ ]  List Funds (with **grantable** balances)
-* [ ]  Search Organizations by EIN
-* [ ]  Create Grant — idempotent, with the Chariot ID carried onto the grant letter
-* [ ]  Get Grant Status (and/or status webhooks)
-* [ ]  Bearer token validation on every endpoint
+* [ ]  Search Organizations by EIN (only if your grant API can't accept an EIN directly)
+* [ ]  Create Grant — **idempotent (required)**, with the Chariot ID carried onto the grant letter
+* [ ]  Get Grant Status
 
 ### Environments
 
@@ -41,7 +41,7 @@ hidden: false
 |---|---|
 | `ISSUER_BASE_URL` | OIDC issuer, ideally with `/.well-known/openid-configuration` |
 | `client_id` / `client_secret` | Per environment |
-| API base URLs + docs | For the five resource endpoints |
+| API base URLs + docs | For your resource endpoints |
 | Refresh token policy | Lifetime, idle timeout, rotation on/off |
 | Sandbox credentials | Test donor logins |
 | Technical contact | For integration support and incident escalation |
@@ -51,7 +51,6 @@ hidden: false
 | Item | |
 |---|---|
 | Redirect URIs | Staging and production callback URLs |
-| Webhook URL + signing secret | If you implement status webhooks |
 | Static IP range | If you require allowlisting |
 | Integration contact | Your dedicated Chariot engineer |
 
@@ -62,20 +61,20 @@ Before launch, Chariot runs a certification pass against your sandbox:
 1. **Auth flows** — happy path, donor cancellation, error redirects, mobile web
 2. **Token lifecycle** — refresh after access-token expiry; rotation grace window (if rotating); behavior after revocation (`invalid_grant`)
 3. **Connection persistence** — refresh succeeds after a simulated dormancy period, verified against your stated refresh-token policy
-4. **Grant lifecycle** — create, duplicate-submission idempotency, status polling/webhooks, rejection with `status_description`
+4. **Grant lifecycle** — create, duplicate-submission idempotency, status polling, rejection with `status_description`
 5. **Edge cases** — multi-fund donors, insufficient balance, unknown EIN, expired access token mid-flow
 
-Once certified, we launch your DAF in DAFpay production behind a flag, run a small set of live test grants together, then enable you for all donors.
+Once certified, we launch your DAF in DAFpay production behind a flag, run a small set of live test grants together, then enable you for all nonprofits.
 
 ## Timeline
 
 | Phase | Owner | Typical duration |
 |---|---|---|
-| Kickoff & credential exchange | Both | 1–3 days |
-| Your build (if using Okta/Auth0 + existing APIs) | You | 3–5 days |
-| Your build (from scratch) | You | 4–8 weeks |
-| Chariot integration build & certification | Chariot | ~2 weeks |
-| Production launch & live verification | Both | 2–3 days |
+| Kickoff & credential exchange | Both | ~1 week |
+| Your build (existing IdP + existing grant APIs) | You | 2–4 weeks |
+| Your build (from scratch) | You | 1–2 months |
+| Chariot integration build & certification | Chariot | 1–2 weeks |
+| Production launch & live verification | Both | ~1 week |
 
 ## FAQ
 
@@ -90,7 +89,3 @@ Yes — but a given donor connection uses one model. Most DAFs choose one; OAuth
 **What happens if a donor's refresh token is revoked?**
 
 On their next donation, DAFpay prompts them to re-link your DAF — they go through your login flow once more, and a fresh long-lived connection is established. Their DAFpay account, history, and Donor Account are unaffected.
-
-**Do you support FDX?**
-
-The endpoint shapes in this guide are intentionally simpler than full FDX, scoped to what a DAF donation flow needs. If you already expose FDX-aligned endpoints, share your documentation — Chariot can adapt to FDX resource shapes during the integration build.

--- a/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
@@ -1,25 +1,10 @@
 ---
 title: "OAuth & Token Requirements"
-subtitle: "What your authorization server must support — including the long-lived connection that makes one-time linking possible."
+subtitle: "What your authorization server must support, and the token policies that keep donor connections alive."
 hidden: false
 ---
 
-## Summary of requirements
-
-| Requirement | Level |
-|---|---|
-| OAuth 2.0 Authorization Code flow | **Required** |
-| OIDC ID Token with stable `sub` claim | **Required** |
-| Refresh tokens (`offline_access`) with **≥ 12-month validity** | Strongly recommended |
-| PKCE (S256) | **Required** |
-| `state` parameter round-trip | **Required** |
-| TLS 1.2+ on all endpoints | **Required** |
-| OIDC Discovery (`/.well-known/openid-configuration`) | Recommended |
-| Refresh token rotation | Optional |
-| Token revocation endpoint (RFC 7009) | Recommended |
-| Consent management portal for donors | Optional |
-
-If you use Okta, Auth0, AWS Cognito, or another standards-compliant identity provider, every required item above is available out of the box — you mainly need to register Chariot as a client and configure token lifetimes.
+Chariot connects to your authorization server using the standard **OAuth 2.0 Authorization Code flow with OIDC**. If you use Okta, Auth0, AWS Cognito, or another standards-compliant identity provider, everything on this page is available out of the box — you mainly need to register Chariot as a client and configure token lifetimes. A [summary of requirements](#summary-of-requirements) is at the end of this page.
 
 ## Client registration
 
@@ -54,6 +39,8 @@ Your server must:
 - Redirect back to `redirect_uri` with `code` and the unmodified `state`.
 - On failure or donor cancellation, redirect back with standard `error` and `error_description` parameters (`access_denied`, `login_required`, etc.) rather than dead-ending the donor.
 
+Chariot always includes PKCE (S256) parameters. Supporting PKCE is recommended as defense-in-depth — see [Security Best Practices](/guides/dafpay/oauth/security#pkce) — but not required: Chariot is a confidential client, and servers that don't support PKCE can ignore the parameters.
+
 <Tip title="Popup-friendly login page">
 The authorization page opens in a **popup window**, not an iframe — so `X-Frame-Options` restrictions are fine. It must, however, render correctly at popup dimensions (~460×720) and on mobile web, where the flow runs as a full-page redirect.
 </Tip>
@@ -82,7 +69,7 @@ Expected response:
   "id_token": "eyJ...",
   "refresh_token": "v1.MjAy...",
   "token_type": "Bearer",
-  "expires_in": 1800,
+  "expires_in": 900,
   "scope": "openid profile email offline_access"
 }
 ```
@@ -100,22 +87,23 @@ The `id_token` must include:
 
 ### Access token
 
-- Lifetime: **10–60 minutes** recommended.
-- JWT access tokens are preferred (validatable by your resource APIs without a network hop), but opaque tokens with introspection are acceptable.
+- Recommended lifetime: **15 minutes** (`expires_in: 900`) — short enough to limit exposure if a token leaks, long enough to avoid excessive refresh traffic.
 
 ## Connection Lifetime
 
+Every DAFpay donor has a persistent Donor Account, and the connection to your DAF is stored against it. Whether a returning donor goes straight to giving — or is bounced back to your login page — is determined by your refresh-token policy.
+
 <Warning title="Long-lived refresh tokens are strongly recommended">
-You are not required to issue long-lived refresh tokens — but we strongly recommend it. Donors set up a DAFpay account and link your DAF to it **once**. Ideally that connection survives across sessions, devices, and months of inactivity — exactly like linking a bank account to a payments app. A donor who returns six months later and is forced to re-authenticate with your login page has a meaningfully degraded experience.
+Donors who return after months away should be able to give without re-linking your DAF — exactly like a bank account linked to a payments app. Short-lived or idle-expiring refresh tokens silently sever those connections, and every severed connection turns a returning donor back into a first-time onboarding flow.
 </Warning>
 
-Specifically, we recommend:
+We recommend:
 
-- **Refresh tokens that remain valid for at least 12 months** — ideally **non-expiring tokens that remain valid until explicitly revoked** by the donor, by you, or by Chariot.
-- If your identity provider enforces an **inactivity (idle) timeout** on refresh tokens, it should be **≥ 12 months**. Chariot only refreshes tokens when the donor is actively donating, so short idle timeouts will silently sever connections for your less-frequent donors.
-- **Do not bind refresh token validity to browser sessions, IP addresses, or device fingerprints.** Token refresh happens server-to-server from Chariot's infrastructure, not from the donor's browser.
+- **Refresh tokens valid for at least 13 months**, or rotated on each use with no fixed expiry. Thirteen months keeps an annual donor — say, a year-end giver — connected through their next donation.
+- **No inactivity (idle) timeouts on refresh tokens.** Chariot only refreshes tokens when the donor is actively donating, so idle timeouts sever connections for exactly your less-frequent donors.
+- **Don't bind refresh-token validity to browser sessions, IP addresses, or device fingerprints.** Token refresh happens server-to-server from Chariot's infrastructure, not from the donor's browser.
 - **Refresh token rotation is supported but optional.** If you rotate, return the new refresh token in every refresh response, and honor the previous token for a short grace window (≥ 60 seconds) to tolerate concurrent refresh races. Chariot always persists the newest token it receives.
-- A donor changing their password **should not** invalidate the refresh token unless your security policy requires it (e.g., suspected account compromise). Routine credential rotation severing donation connections creates support burden on both sides.
+- **If you need to revoke tokens outside the flows below** — a security incident, a policy change, an account migration — coordinate with Chariot first so we can prompt affected donors to reconnect, rather than their connections failing silently at the next donation.
 
 ### Refresh request
 
@@ -143,14 +131,25 @@ When Chariot receives `invalid_grant` on refresh (or a hard `401` on resource ca
 Like Plaid's Permissions Manager model, you may optionally offer donors a consent-management view in your portal listing their active DAFpay connection with the ability to revoke it. This is good practice but not required for launch.
 </Note>
 
-## Token storage on Chariot's side
-
-Chariot stores refresh tokens encrypted at rest (envelope encryption, per-token data keys), never logs token values, and scopes each token to a single Donor Account. Tokens are used exclusively for the donor-authorized operations described in [API Endpoints](/guides/dafpay/oauth/api-endpoints).
-
 ## What Chariot needs from you
 
 - `ISSUER_BASE_URL` — your OIDC issuer (ideally with a discovery document)
 - `client_id` and `client_secret` for each environment
 - API base URLs and documentation for the [resource endpoints](/guides/dafpay/oauth/api-endpoints)
 - Sandbox environment details and at least 2 test donor accounts (one with multiple funds)
-- Configured refresh-token lifetime policy (so we can verify it meets the Connection Lifetime requirements)
+- Configured refresh-token lifetime policy (so we can verify it meets the Connection Lifetime recommendations)
+
+## Summary of requirements
+
+| Requirement | Level |
+|---|---|
+| OAuth 2.0 Authorization Code flow | **Required** |
+| OIDC ID Token with stable `sub` claim | **Required** |
+| `state` parameter round-trip | **Required** |
+| TLS 1.2+ on all endpoints | **Required** |
+| Refresh tokens (`offline_access`) valid **13+ months** (or rotating, no fixed expiry) | Strongly recommended |
+| PKCE (S256) | Recommended |
+| OIDC Discovery (`/.well-known/openid-configuration`) | Recommended |
+| Token revocation endpoint (RFC 7009) | Recommended |
+| Refresh token rotation | Optional |
+| Consent management portal for donors | Optional |

--- a/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OAuth & Token Requirements"
-subtitle: "What your authorization server must support — including the long-lived connection that makes one-time linking possible."
+subtitle: "What your authorization server must support — including the token lifecycle that keeps donors connected between donations."
 hidden: false
 ---
 
@@ -10,12 +10,12 @@ hidden: false
 |---|---|
 | OAuth 2.0 Authorization Code flow | **Required** |
 | OIDC ID Token with stable `sub` claim | **Required** |
-| Refresh tokens (`offline_access`) with **≥ 12-month validity** | Strongly recommended |
+| Refresh tokens (`offline_access`) | **Required** |
+| Refresh token rotation on each use — or **13+ month expiry** | Strongly recommended |
 | PKCE (S256) | **Required** |
 | `state` parameter round-trip | **Required** |
 | TLS 1.2+ on all endpoints | **Required** |
 | OIDC Discovery (`/.well-known/openid-configuration`) | Recommended |
-| Refresh token rotation | Optional |
 | Token revocation endpoint (RFC 7009) | Recommended |
 | Consent management portal for donors | Optional |
 
@@ -82,7 +82,7 @@ Expected response:
   "id_token": "eyJ...",
   "refresh_token": "v1.MjAy...",
   "token_type": "Bearer",
-  "expires_in": 1800,
+  "expires_in": 900,
   "scope": "openid profile email offline_access"
 }
 ```
@@ -100,21 +100,25 @@ The `id_token` must include:
 
 ### Access token
 
-- Lifetime: **10–60 minutes** recommended.
+- Lifetime: **15 minutes**.
 - JWT access tokens are preferred (validatable by your resource APIs without a network hop), but opaque tokens with introspection are acceptable.
 
 ## Connection Lifetime
 
-<Warning title="Long-lived refresh tokens are strongly recommended">
-You are not required to issue long-lived refresh tokens — but we strongly recommend it. Donors set up a DAFpay account and link your DAF to it **once**. Ideally that connection survives across sessions, devices, and months of inactivity — exactly like linking a bank account to a payments app. A donor who returns six months later and is forced to re-authenticate with your login page has a meaningfully degraded experience.
+<Warning title="Keep connections durable">
+A donor's connection to your DAF should persist across sessions, devices, and months of inactivity — like linking a bank account to a payments app. Donors will periodically re-authenticate to meet reauthorization requirements, but a donor who is forced through your login flow on every donation has a meaningfully degraded experience.
 </Warning>
 
-Specifically, we recommend:
+The **refresh token** is a long-lived token used to obtain new access tokens. It should be either:
 
-- **Refresh tokens that remain valid for at least 12 months** — ideally **non-expiring tokens that remain valid until explicitly revoked** by the donor, by you, or by Chariot.
-- If your identity provider enforces an **inactivity (idle) timeout** on refresh tokens, it should be **≥ 12 months**. Chariot only refreshes tokens when the donor is actively donating, so short idle timeouts will silently sever connections for your less-frequent donors.
+- **Rotated with each use (preferred)** — every refresh response returns a new refresh token, restarting its validity window. Active donors stay connected without re-authenticating, and dormant connections age out naturally.
+- **Or set to expire after 13+ months** — long enough that a donor who gives annually can return without re-linking, while still meeting reauthorization requirements.
+
+Additionally:
+
+- If your identity provider enforces an **inactivity (idle) timeout** on refresh tokens, it should be **≥ 13 months**. Chariot only refreshes tokens when the donor is actively donating, so short idle timeouts will silently sever connections for your less-frequent donors.
 - **Do not bind refresh token validity to browser sessions, IP addresses, or device fingerprints.** Token refresh happens server-to-server from Chariot's infrastructure, not from the donor's browser.
-- **Refresh token rotation is supported but optional.** If you rotate, return the new refresh token in every refresh response, and honor the previous token for a short grace window (≥ 60 seconds) to tolerate concurrent refresh races. Chariot always persists the newest token it receives.
+- **If you rotate**, return the new refresh token in every refresh response, and honor the previous token for a short grace window (≥ 60 seconds) to tolerate concurrent refresh races. Chariot always persists the newest token it receives.
 - A donor changing their password **should not** invalidate the refresh token unless your security policy requires it (e.g., suspected account compromise). Routine credential rotation severing donation connections creates support burden on both sides.
 
 ### Refresh request
@@ -131,13 +135,14 @@ grant_type=refresh_token
 
 ### When connections end
 
-A connection should end in exactly three ways:
+A connection ends in one of four ways:
 
-1. **Donor-initiated** — the donor unlinks your DAF inside DAFpay. Chariot calls your revocation endpoint (RFC 7009) if available, then deletes its stored tokens.
-2. **You revoke** — e.g., the donor closes their DAF account, or requests disconnection through your support team or consent portal. Subsequent refresh attempts should return `invalid_grant`.
-3. **Chariot revokes** — fraud or risk signals on our side.
+1. **Expiry** — the refresh token reaches the end of its validity window without being rotated. The donor reauthorizes on their next donation. This is the normal reauthorization path for dormant connections.
+2. **Donor-initiated** — the donor unlinks your DAF inside DAFpay. Chariot calls your revocation endpoint (RFC 7009) if available, then deletes its stored tokens.
+3. **You revoke** — e.g., the donor closes their DAF account, or requests disconnection through your support team or consent portal. Subsequent refresh attempts should return `invalid_grant`.
+4. **Chariot revokes** — fraud or risk signals on our side.
 
-When Chariot receives `invalid_grant` on refresh (or a hard `401` on resource calls that a refresh doesn't fix), we mark the connection as disconnected and prompt the donor to re-link on their next donation. This should be the exception, not the routine.
+When Chariot receives `invalid_grant` on refresh (or a hard `401` on resource calls that a refresh doesn't fix), we mark the connection as disconnected and prompt the donor to re-link on their next donation. Re-linking is lightweight — the donor signs in on your login page once more and a fresh connection is established.
 
 <Note>
 Like Plaid's Permissions Manager model, you may optionally offer donors a consent-management view in your portal listing their active DAFpay connection with the ability to revoke it. This is good practice but not required for launch.
@@ -153,4 +158,4 @@ Chariot stores refresh tokens encrypted at rest (envelope encryption, per-token 
 - `client_id` and `client_secret` for each environment
 - API base URLs and documentation for the [resource endpoints](/guides/dafpay/oauth/api-endpoints)
 - Sandbox environment details and at least 2 test donor accounts (one with multiple funds)
-- Configured refresh-token lifetime policy (so we can verify it meets the Connection Lifetime requirements)
+- Configured refresh-token policy — rotation on/off, lifetime, idle timeout (so we can verify it meets the Connection Lifetime guidance)

--- a/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
@@ -10,7 +10,7 @@ hidden: false
 |---|---|
 | OAuth 2.0 Authorization Code flow | **Required** |
 | OIDC ID Token with stable `sub` claim | **Required** |
-| Refresh tokens (`offline_access`) with **≥ 12-month validity** | **Required** |
+| Refresh tokens (`offline_access`) with **≥ 12-month validity** | Strongly recommended |
 | PKCE (S256) | **Required** |
 | `state` parameter round-trip | **Required** |
 | TLS 1.2+ on all endpoints | **Required** |
@@ -105,14 +105,14 @@ The `id_token` must include:
 
 ## Connection Lifetime
 
-<Warning title="The single most important requirement in this guide">
-**Your refresh tokens must be long-lived.** Donors set up a DAFpay account and link your DAF to it **once**. That connection must survive across sessions, devices, and months of inactivity — exactly like linking a bank account to a payments app. A donor who returns six months later and is forced to re-authenticate with your login page is, for practical purposes, a broken integration.
+<Warning title="Long-lived refresh tokens are strongly recommended">
+You are not required to issue long-lived refresh tokens — but we strongly recommend it. Donors set up a DAFpay account and link your DAF to it **once**. Ideally that connection survives across sessions, devices, and months of inactivity — exactly like linking a bank account to a payments app. A donor who returns six months later and is forced to re-authenticate with your login page has a meaningfully degraded experience.
 </Warning>
 
-Specifically:
+Specifically, we recommend:
 
-- **Refresh tokens must remain valid for at least 12 months**, and we strongly recommend **non-expiring tokens that remain valid until explicitly revoked** by the donor, by you, or by Chariot.
-- If your identity provider enforces an **inactivity (idle) timeout** on refresh tokens, it must be **≥ 12 months**. Chariot only refreshes tokens when the donor is actively donating, so short idle timeouts will silently sever connections for your less-frequent donors.
+- **Refresh tokens that remain valid for at least 12 months** — ideally **non-expiring tokens that remain valid until explicitly revoked** by the donor, by you, or by Chariot.
+- If your identity provider enforces an **inactivity (idle) timeout** on refresh tokens, it should be **≥ 12 months**. Chariot only refreshes tokens when the donor is actively donating, so short idle timeouts will silently sever connections for your less-frequent donors.
 - **Do not bind refresh token validity to browser sessions, IP addresses, or device fingerprints.** Token refresh happens server-to-server from Chariot's infrastructure, not from the donor's browser.
 - **Refresh token rotation is supported but optional.** If you rotate, return the new refresh token in every refresh response, and honor the previous token for a short grace window (≥ 60 seconds) to tolerate concurrent refresh races. Chariot always persists the newest token it receives.
 - A donor changing their password **should not** invalidate the refresh token unless your security policy requires it (e.g., suspected account compromise). Routine credential rotation severing donation connections creates support burden on both sides.

--- a/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OAuth & Token Requirements"
-subtitle: "What your authorization server must support — including the token lifecycle that keeps donors connected between donations."
+subtitle: "What your authorization server must support."
 hidden: false
 ---
 

--- a/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/oauth-requirements.mdx
@@ -1,0 +1,156 @@
+---
+title: "OAuth & Token Requirements"
+subtitle: "What your authorization server must support — including the long-lived connection that makes one-time linking possible."
+hidden: false
+---
+
+## Summary of requirements
+
+| Requirement | Level |
+|---|---|
+| OAuth 2.0 Authorization Code flow | **Required** |
+| OIDC ID Token with stable `sub` claim | **Required** |
+| Refresh tokens (`offline_access`) with **≥ 12-month validity** | **Required** |
+| PKCE (S256) | **Required** |
+| `state` parameter round-trip | **Required** |
+| TLS 1.2+ on all endpoints | **Required** |
+| OIDC Discovery (`/.well-known/openid-configuration`) | Recommended |
+| Refresh token rotation | Optional |
+| Token revocation endpoint (RFC 7009) | Recommended |
+| Consent management portal for donors | Optional |
+
+If you use Okta, Auth0, AWS Cognito, or another standards-compliant identity provider, every required item above is available out of the box — you mainly need to register Chariot as a client and configure token lifetimes.
+
+## Client registration
+
+Register Chariot as a **confidential client** (server-side code exchange) in your authorization server, with redirect URIs for each environment:
+
+| Environment | Callback URL |
+|---|---|
+| Production | `https://api.givechariot.com/oauth/callback` |
+| Staging | `https://devapi.givechariot.com/oauth/callback` |
+
+You'll provide Chariot with the resulting `client_id` and `client_secret` through a secure channel (we'll share a secure link during onboarding — never email secrets).
+
+## Authorization request
+
+Chariot launches your authorization endpoint in a popup window:
+
+```
+GET https://auth.{your-domain}.com/authorize
+  ?response_type=code
+  &client_id={CHARIOT_CLIENT_ID}
+  &redirect_uri=https://api.givechariot.com/oauth/callback
+  &scope=openid profile email offline_access
+  &state={opaque-csrf-token}
+  &code_challenge={S256-challenge}
+  &code_challenge_method=S256
+```
+
+Your server must:
+
+- Authenticate the donor on **your** hosted login page (your branding, your MFA policy).
+- Display a consent step (or pre-configured consent) covering the scopes requested.
+- Redirect back to `redirect_uri` with `code` and the unmodified `state`.
+- On failure or donor cancellation, redirect back with standard `error` and `error_description` parameters (`access_denied`, `login_required`, etc.) rather than dead-ending the donor.
+
+<Tip title="Popup-friendly login page">
+The authorization page opens in a **popup window**, not an iframe — so `X-Frame-Options` restrictions are fine. It must, however, render correctly at popup dimensions (~460×720) and on mobile web, where the flow runs as a full-page redirect.
+</Tip>
+
+## Token exchange
+
+Chariot exchanges the authorization code server-to-server:
+
+```
+POST https://auth.{your-domain}.com/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code={code}
+&redirect_uri=https://api.givechariot.com/oauth/callback
+&client_id={CHARIOT_CLIENT_ID}
+&client_secret={CHARIOT_CLIENT_SECRET}
+&code_verifier={pkce-verifier}
+```
+
+Expected response:
+
+```json
+{
+  "access_token": "eyJ...",
+  "id_token": "eyJ...",
+  "refresh_token": "v1.MjAy...",
+  "token_type": "Bearer",
+  "expires_in": 1800,
+  "scope": "openid profile email offline_access"
+}
+```
+
+### ID Token claims
+
+The `id_token` must include:
+
+| Claim | Requirement |
+|---|---|
+| `sub` | **Stable, unique, and permanent** identifier for the donor. Chariot uses `sub` to bind your donor to their DAFpay Donor Account. It must never change for a given donor and must never be reused for another donor. |
+| `email` | Donor's email address |
+| `email_verified` | Recommended |
+| `name` / `given_name` / `family_name` | Recommended |
+
+### Access token
+
+- Lifetime: **10–60 minutes** recommended.
+- JWT access tokens are preferred (validatable by your resource APIs without a network hop), but opaque tokens with introspection are acceptable.
+
+## Connection Lifetime
+
+<Warning title="The single most important requirement in this guide">
+**Your refresh tokens must be long-lived.** Donors set up a DAFpay account and link your DAF to it **once**. That connection must survive across sessions, devices, and months of inactivity — exactly like linking a bank account to a payments app. A donor who returns six months later and is forced to re-authenticate with your login page is, for practical purposes, a broken integration.
+</Warning>
+
+Specifically:
+
+- **Refresh tokens must remain valid for at least 12 months**, and we strongly recommend **non-expiring tokens that remain valid until explicitly revoked** by the donor, by you, or by Chariot.
+- If your identity provider enforces an **inactivity (idle) timeout** on refresh tokens, it must be **≥ 12 months**. Chariot only refreshes tokens when the donor is actively donating, so short idle timeouts will silently sever connections for your less-frequent donors.
+- **Do not bind refresh token validity to browser sessions, IP addresses, or device fingerprints.** Token refresh happens server-to-server from Chariot's infrastructure, not from the donor's browser.
+- **Refresh token rotation is supported but optional.** If you rotate, return the new refresh token in every refresh response, and honor the previous token for a short grace window (≥ 60 seconds) to tolerate concurrent refresh races. Chariot always persists the newest token it receives.
+- A donor changing their password **should not** invalidate the refresh token unless your security policy requires it (e.g., suspected account compromise). Routine credential rotation severing donation connections creates support burden on both sides.
+
+### Refresh request
+
+```
+POST https://auth.{your-domain}.com/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=refresh_token
+&refresh_token={refresh_token}
+&client_id={CHARIOT_CLIENT_ID}
+&client_secret={CHARIOT_CLIENT_SECRET}
+```
+
+### When connections end
+
+A connection should end in exactly three ways:
+
+1. **Donor-initiated** — the donor unlinks your DAF inside DAFpay. Chariot calls your revocation endpoint (RFC 7009) if available, then deletes its stored tokens.
+2. **You revoke** — e.g., the donor closes their DAF account, or requests disconnection through your support team or consent portal. Subsequent refresh attempts should return `invalid_grant`.
+3. **Chariot revokes** — fraud or risk signals on our side.
+
+When Chariot receives `invalid_grant` on refresh (or a hard `401` on resource calls that a refresh doesn't fix), we mark the connection as disconnected and prompt the donor to re-link on their next donation. This should be the exception, not the routine.
+
+<Note>
+Like Plaid's Permissions Manager model, you may optionally offer donors a consent-management view in your portal listing their active DAFpay connection with the ability to revoke it. This is good practice but not required for launch.
+</Note>
+
+## Token storage on Chariot's side
+
+Chariot stores refresh tokens encrypted at rest (envelope encryption, per-token data keys), never logs token values, and scopes each token to a single Donor Account. Tokens are used exclusively for the donor-authorized operations described in [API Endpoints](/guides/dafpay/oauth/api-endpoints).
+
+## What Chariot needs from you
+
+- `ISSUER_BASE_URL` — your OIDC issuer (ideally with a discovery document)
+- `client_id` and `client_secret` for each environment
+- API base URLs and documentation for the [resource endpoints](/guides/dafpay/oauth/api-endpoints)
+- Sandbox environment details and at least 2 test donor accounts (one with multiple funds)
+- Configured refresh-token lifetime policy (so we can verify it meets the Connection Lifetime requirements)

--- a/fern/versions/v2026-04-01/pages/oauth/overview.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/overview.mdx
@@ -20,7 +20,7 @@ This is the same model used across open finance (e.g., Plaid's FDX-aligned Core 
 
 - They sign in with the credentials they already have — on your branded login page. You control the authentication experience, including MFA.
 - They see their real fund names and grantable balances inside the donation flow.
-- **They link once.** DAFpay donors have persistent Donor Accounts. After the first connection, returning donors authenticate with DAFpay only — they are not asked to re-link their DAF. (See [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime).)
+- **They rarely re-link.** DAFpay donors have persistent Donor Accounts. While their connection to your DAF is active, returning donors authenticate with DAFpay only — they're asked to re-link only when the connection expires or is revoked. (See [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime).)
 
 **For you:**
 
@@ -38,7 +38,7 @@ This is the same model used across open finance (e.g., Plaid's FDX-aligned Core 
 | Grant creation | You decision Grant Requests via Chariot's API | Chariot creates grants via your API |
 | Best for | DAFs without API infrastructure | DAFs with (or building) OAuth + APIs |
 
-Both integrations result in the same thing for donors: a one-time setup, after which giving via DAFpay is instant.
+Both integrations result in the same thing for donors: after the initial setup, giving via DAFpay is instant.
 
 ## The flow
 
@@ -73,7 +73,7 @@ Donor                      DAFpay (Chariot)                 DAF (you)
   │                          │ ◄──────────────────────────────│
 ```
 
-**On every future donation**, the donor signs in to DAFpay only. Chariot silently refreshes its access token using the long-lived refresh token from step 5 and proceeds straight to steps 6–9. Your login page is never shown again unless the connection has been revoked.
+**On future donations**, the donor signs in to DAFpay only. Chariot silently refreshes its access token using the refresh token from step 5 and proceeds straight to steps 6–9. Your login page reappears only when the connection ends — when the donor's refresh token expires (reauthorization) or the connection is revoked.
 
 ## What you'll build
 

--- a/fern/versions/v2026-04-01/pages/oauth/overview.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/overview.mdx
@@ -1,16 +1,16 @@
 ---
 title: "OAuth Integration"
-subtitle: "Donors connect their DAF with the credentials they already have — and give seamlessly at checkout."
+subtitle: "Let donors link their DAF account to DAFpay once — and give seamlessly at checkout."
 hidden: false
 ---
 
 <Note title="Audience">
-This guide is for **Donor Advised Fund (DAF) providers** who operate (or are willing to build) their own OAuth 2.0 / OIDC authorization server and a small set of APIs. If you'd prefer an integration with no engineering beyond a single API call, see [Donor Accounts](/guides/dafpay/donor-accounts/overview) instead.
+This guide is for **Donor Advised Fund (DAF) providers** who operate their own OAuth 2.0 / OIDC authorization server and a small set of APIs. If you'd prefer an integration with no engineering beyond a few API calls, see [Donor Accounts](/guides/dafpay/donor-accounts/overview) instead.
 </Note>
 
 ## Overview
 
-The OAuth Integration is the deepest way to connect your DAF to DAFpay. Instead of verifying donors with one-time codes, donors authenticate **directly on your login page** and are redirected back to DAFpay to complete their donation. DAFpay then communicates with your APIs to display fund balances, create grants, and track grant status — all under the donor's authorization.
+The OAuth Integration is an alternative way to connect your DAF to DAFpay. Instead of verifying donors with one-time codes, donors authenticate **directly on your login page** and are redirected back to DAFpay to complete their donation. DAFpay then communicates with your APIs to display fund balances, create grants, and track grant status — all under the donor's authorization.
 
 This is the same model used across open finance — it's how banks connect customer accounts to payment apps through aggregators like Plaid — scoped down to the handful of endpoints a DAF actually needs. If you already run Okta, Auth0, Cognito, or a custom OIDC-compliant identity provider, most of the authentication work is configuration rather than code.
 

--- a/fern/versions/v2026-04-01/pages/oauth/overview.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OAuth Integration"
-subtitle: "Let donors link their DAF account to DAFpay once — and give from anywhere, forever."
+subtitle: "Let donors link their DAF account to DAFpay once — and give seamlessly at checkout."
 hidden: false
 ---
 
@@ -20,7 +20,7 @@ This is the same model used across open finance (e.g., Plaid's FDX-aligned Core 
 
 - They sign in with the credentials they already have — on your branded login page. You control the authentication experience, including MFA.
 - They see their real fund names and grantable balances inside the donation flow.
-- **They link once.** DAFpay donors have persistent Donor Accounts. After the first connection, returning donors authenticate with DAFpay only — they are not asked to re-link their DAF. (See [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime) — this is the most important requirement in this guide.)
+- **They link once.** DAFpay donors have persistent Donor Accounts. After the first connection, returning donors authenticate with DAFpay only — they are not asked to re-link their DAF. (See [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime).)
 
 **For you:**
 

--- a/fern/versions/v2026-04-01/pages/oauth/overview.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/overview.mdx
@@ -1,0 +1,92 @@
+---
+title: "OAuth Integration"
+subtitle: "Let donors link their DAF account to DAFpay once — and give from anywhere, forever."
+hidden: false
+---
+
+<Note title="Audience">
+This guide is for **Donor Advised Fund (DAF) providers** who operate (or are willing to build) their own OAuth 2.0 / OIDC authorization server and a small set of APIs. If you'd prefer an integration with no engineering beyond a single API call, see [Donor Accounts](/guides/dafpay/donor-accounts/overview) instead.
+</Note>
+
+## Overview
+
+The OAuth Integration is the deepest way to connect your DAF to DAFpay. Instead of verifying donors with one-time codes, donors authenticate **directly on your login page** and are redirected back to DAFpay to complete their donation. DAFpay then communicates with your APIs to display fund balances, create grants, and track grant status — all under the donor's authorization.
+
+This is the same model used across open finance (e.g., Plaid's FDX-aligned Core Exchange for banks), scoped down to the handful of endpoints a DAF actually needs. If you already run Okta, Auth0, Cognito, or a custom OIDC-compliant identity provider, most of the authentication work is configuration rather than code.
+
+## Why this model
+
+**For your donors:**
+
+- They sign in with the credentials they already have — on your branded login page. You control the authentication experience, including MFA.
+- They see their real fund names and grantable balances inside the donation flow.
+- **They link once.** DAFpay donors have persistent Donor Accounts. After the first connection, returning donors authenticate with DAFpay only — they are not asked to re-link their DAF. (See [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime) — this is the most important requirement in this guide.)
+
+**For you:**
+
+- Grants are created through your own API, so they flow through your existing review and disbursement pipeline. No separate decisioning queue.
+- You never share donor credentials with Chariot — only scoped, revocable tokens.
+- Real-time, accurate balances mean fewer failed or reduced grants.
+
+## How it compares to Donor Accounts
+
+| | **Donor Accounts** | **OAuth Integration** |
+|---|---|---|
+| Engineering lift | One API call | OAuth server + 4–5 API endpoints |
+| Donor verification | One-time code exchange | Donor signs in on your login page |
+| Fund balances shown | No | Yes, real-time |
+| Grant creation | You decision Grant Requests via Chariot's API | Chariot creates grants via your API |
+| Best for | DAFs without API infrastructure | DAFs with (or building) OAuth + APIs |
+
+Both integrations result in the same thing for donors: a one-time setup, after which giving via DAFpay is instant.
+
+## The flow
+
+```
+Donor                      DAFpay (Chariot)                 DAF (you)
+  │                          │                                │
+  │  1. Select your DAF      │                                │
+  │ ────────────────────────▶│                                │
+  │                          │  2. Redirect to your           │
+  │                          │     Authorize URL (popup)      │
+  │ ◄────────────────────────│                                │
+  │                          │                                │
+  │  3. Sign in & consent on your login page                  │
+  │ ─────────────────────────────────────────────────────────▶│
+  │                          │                                │
+  │                          │  4. Redirect to Chariot        │
+  │                          │     callback with auth code    │
+  │                          │ ◄──────────────────────────────│
+  │                          │                                │
+  │                          │  5. Exchange code for tokens   │
+  │                          │     (access + refresh + id)    │
+  │                          │ ◄─────────────────────────────▶│
+  │                          │                                │
+  │                          │  6. GET /funds, /customers     │
+  │                          │ ◄─────────────────────────────▶│
+  │  7. Review fund & balance│                                │
+  │ ◄────────────────────────│                                │
+  │  8. Submit grant         │                                │
+  │ ────────────────────────▶│  9. POST /grants               │
+  │                          │ ──────────────────────────────▶│
+  │                          │  10. Grant status updates      │
+  │                          │ ◄──────────────────────────────│
+```
+
+**On every future donation**, the donor signs in to DAFpay only. Chariot silently refreshes its access token using the long-lived refresh token from step 5 and proceeds straight to steps 6–9. Your login page is never shown again unless the connection has been revoked.
+
+## What you'll build
+
+1. **An OAuth 2.0 / OIDC authorization server** with a Chariot client registration — see [OAuth & Token Requirements](/guides/dafpay/oauth/oauth-requirements)
+2. **Resource APIs** that Chariot calls with the donor's access token — see [API Endpoints](/guides/dafpay/oauth/api-endpoints)
+3. **A sandbox environment** with test donor accounts for integration testing — see [Integration Checklist](/guides/dafpay/oauth/integration-checklist)
+
+## Estimated timeline
+
+| Your current setup | Estimated effort |
+|---|---|
+| Existing Okta / Auth0 / Cognito + internal grant APIs | ~1 engineer, 3–5 days of configuration + API adaptation |
+| Existing identity provider, no external-facing APIs | ~2–4 weeks |
+| Building auth and APIs from scratch | ~4–8 weeks |
+
+Chariot requires roughly **2 weeks** to build, test, and certify the integration on our side once your sandbox is available.

--- a/fern/versions/v2026-04-01/pages/oauth/overview.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OAuth Integration"
-subtitle: "Let donors link their DAF account to DAFpay once — and give seamlessly at checkout."
+subtitle: "Donors connect their DAF with the credentials they already have — and give seamlessly at checkout."
 hidden: false
 ---
 
@@ -12,7 +12,7 @@ This guide is for **Donor Advised Fund (DAF) providers** who operate (or are wil
 
 The OAuth Integration is the deepest way to connect your DAF to DAFpay. Instead of verifying donors with one-time codes, donors authenticate **directly on your login page** and are redirected back to DAFpay to complete their donation. DAFpay then communicates with your APIs to display fund balances, create grants, and track grant status — all under the donor's authorization.
 
-This is the same model used across open finance (e.g., Plaid's FDX-aligned Core Exchange for banks), scoped down to the handful of endpoints a DAF actually needs. If you already run Okta, Auth0, Cognito, or a custom OIDC-compliant identity provider, most of the authentication work is configuration rather than code.
+This is the same model used across open finance — it's how banks connect customer accounts to payment apps through aggregators like Plaid — scoped down to the handful of endpoints a DAF actually needs. If you already run Okta, Auth0, Cognito, or a custom OIDC-compliant identity provider, most of the authentication work is configuration rather than code.
 
 ## Why this model
 
@@ -20,13 +20,13 @@ This is the same model used across open finance (e.g., Plaid's FDX-aligned Core 
 
 - They sign in with the credentials they already have — on your branded login page. You control the authentication experience, including MFA.
 - They see their real fund names and grantable balances inside the donation flow.
-- **They link once.** DAFpay donors have persistent Donor Accounts. After the first connection, returning donors authenticate with DAFpay only — they are not asked to re-link their DAF. (See [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime).)
+- **A streamlined returning experience.** Every donor creates a persistent DAFpay Donor Account at their first checkout. As long as the connection to your DAF remains active, returning donors verify with DAFpay only — they aren't sent back through your login page on each donation. Connection persistence is determined by your refresh-token policy; see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime).
 
 **For you:**
 
 - Grants are created through your own API, so they flow through your existing review and disbursement pipeline. No separate decisioning queue.
 - You never share donor credentials with Chariot — only scoped, revocable tokens.
-- Real-time, accurate balances mean fewer failed or reduced grants.
+- Real-time, accurate balances mean fewer failed grants.
 
 ## How it compares to Donor Accounts
 
@@ -36,9 +36,9 @@ This is the same model used across open finance (e.g., Plaid's FDX-aligned Core 
 | Donor verification | One-time code exchange | Donor signs in on your login page |
 | Fund balances shown | No | Yes, real-time |
 | Grant creation | You decision Grant Requests via Chariot's API | Chariot creates grants via your API |
-| Best for | DAFs without API infrastructure | DAFs with (or building) OAuth + APIs |
+| Best for | DAFs without API infrastructure | DAFs with OAuth + APIs |
 
-Both integrations result in the same thing for donors: a one-time setup, after which giving via DAFpay is instant.
+In both models, returning donors verify with DAFpay and give in seconds — without re-entering DAF credentials, for as long as the connection remains active.
 
 ## The flow
 
@@ -73,7 +73,7 @@ Donor                      DAFpay (Chariot)                 DAF (you)
   │                          │ ◄──────────────────────────────│
 ```
 
-**On every future donation**, the donor signs in to DAFpay only. Chariot silently refreshes its access token using the long-lived refresh token from step 5 and proceeds straight to steps 6–9. Your login page is never shown again unless the connection has been revoked.
+**On future donations**, the donor verifies with DAFpay only. While the connection remains active, Chariot silently refreshes its access token using the refresh token from step 5 and proceeds straight to steps 6–9 — your login page is shown again only if the connection has expired or been revoked (see [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime)).
 
 ## What you'll build
 
@@ -81,12 +81,14 @@ Donor                      DAFpay (Chariot)                 DAF (you)
 2. **Resource APIs** that Chariot calls with the donor's access token — see [API Endpoints](/guides/dafpay/oauth/api-endpoints)
 3. **A sandbox environment** with test donor accounts for integration testing — see [Integration Checklist](/guides/dafpay/oauth/integration-checklist)
 
+Throughout the build, follow the [Security Best Practices](/guides/dafpay/oauth/security) — transport security, credential handling, token policy, and the scope boundaries that keep Chariot's access limited to DAF granting and nothing else.
+
 ## Estimated timeline
 
 | Your current setup | Estimated effort |
 |---|---|
-| Existing Okta / Auth0 / Cognito + internal grant APIs | ~1 engineer, 3–5 days of configuration + API adaptation |
-| Existing identity provider, no external-facing APIs | ~2–4 weeks |
-| Building auth and APIs from scratch | ~4–8 weeks |
+| Existing Okta / Auth0 / Cognito + internal grant APIs | ~2–4 weeks of configuration + API adaptation |
+| Existing identity provider, no external-facing APIs | ~1–2 months |
+| Building auth and APIs from scratch | ~1–2 months |
 
-Chariot requires roughly **2 weeks** to build, test, and certify the integration on our side once your sandbox is available.
+Chariot requires roughly **1–2 weeks** to build, test, and certify the integration on our side once your sandbox is available.

--- a/fern/versions/v2026-04-01/pages/oauth/security.mdx
+++ b/fern/versions/v2026-04-01/pages/oauth/security.mdx
@@ -1,0 +1,61 @@
+---
+title: "Security Best Practices"
+subtitle: "Keeping the connection scoped, encrypted, and revocable — on both sides."
+hidden: false
+---
+
+The integration is designed so that Chariot holds **scoped, revocable tokens — never donor credentials**. This page collects the security practices we recommend (and a few we require) on top of the [OAuth & Token Requirements](/guides/dafpay/oauth/oauth-requirements). If you run a standards-compliant identity provider, most of these are configuration rather than code.
+
+## Scope of access
+
+Many DAF providers operate within a larger financial institution, where the same donor login also reaches brokerage, banking, or investment accounts. **The access you grant Chariot must never extend to those systems.**
+
+- Tokens issued to Chariot should authorize only the capabilities in [API Endpoints](/guides/dafpay/oauth/api-endpoints): the donor's profile, their funds and grantable balances, grant creation, and grant status.
+- If your authorization server fronts multiple lines of business, issue DAF tokens with a dedicated scope or audience, and reject those tokens everywhere else.
+- Never return investment positions, bank balances, or transaction history from the endpoints Chariot calls — DAFpay neither needs nor wants that data.
+
+## Transport security
+
+- **TLS 1.2 or higher on every endpoint** — authorization, token, discovery/JWKS, and resource APIs. This is required.
+- Production endpoints must present valid CA-signed certificates. Self-signed certificates are acceptable in sandbox if you let us know in advance.
+
+## Credential management
+
+- Exchange `client_secret`s through the secure channel Chariot provides during onboarding — never over email.
+- Generate secrets with a cryptographically secure random generator (CSPRNG).
+- **Never store client secrets in plaintext.** Use a secrets manager, or at minimum encrypt them at rest in your database.
+- When rotating Chariot's client secret, coordinate with us and keep both secrets valid during the cutover so live donor connections aren't interrupted.
+
+## Token security
+
+- Issue **short-lived access tokens** (15 minutes recommended) and long-lived refresh tokens per [Connection Lifetime](/guides/dafpay/oauth/oauth-requirements#connection-lifetime).
+- Validate the Bearer token on every resource API request — signature (or introspection), expiry, and scope/audience.
+- Build a way to revoke tokens when a donor disconnects or you detect suspicious activity. A standard revocation endpoint (RFC 7009) is recommended; Chariot calls it when a donor unlinks your DAF.
+
+## PKCE
+
+Chariot includes PKCE parameters (`code_challenge` with S256) on every authorization request and the matching `code_verifier` at token exchange. Supporting PKCE is **recommended, not required**: Chariot is a confidential client authenticating with a client secret, so PKCE here is defense-in-depth against authorization-code interception rather than a necessity. Servers that don't support PKCE can ignore the parameters.
+
+## Signing key rotation (JWKS)
+
+If you issue JWT tokens, publish your signing keys at the JWKS URI referenced by your discovery document, and:
+
+- Rotate signing keys at least once a year.
+- Publish a new key **before** removing the old one, and keep both available for at least 24 hours so Chariot's key cache can roll over.
+- Give every key a unique `kid`.
+- Don't IP-restrict your discovery or JWKS endpoints — they contain only public material, and Chariot (like your other clients) must reach them freely.
+
+## IP allowlisting
+
+All Chariot traffic — token exchanges, refreshes, and resource API calls — originates from a static IP range we share during onboarding. You may allowlist this range on your token and resource endpoints as defense-in-depth. Two caveats:
+
+- Allowlisting complements token validation; it never replaces it.
+- Keep discovery and JWKS endpoints publicly reachable (see above).
+
+## How Chariot protects your tokens
+
+Chariot stores refresh tokens encrypted at rest (envelope encryption, per-token data keys), never logs token values, and scopes each token to a single Donor Account. Tokens are used exclusively for the donor-authorized operations described in [API Endpoints](/guides/dafpay/oauth/api-endpoints), and stored tokens are deleted when a connection ends.
+
+## Incident coordination
+
+During onboarding we exchange technical and security contacts on both sides. If you detect suspicious activity involving Chariot's client, or need to revoke tokens in bulk (e.g., a security incident or an account migration), contact us first whenever possible — we'll prompt affected donors to reconnect rather than leaving them with silently broken connections.


### PR DESCRIPTION
Adds a four-page guide for DAF providers integrating with DAFpay via OAuth 2.0 / OIDC: overview, OAuth & token requirements, recommended resource API endpoints, and an integration/certification checklist. Placed in the nav directly after Donor Accounts (for DAFs) under the DAFpay section in v2026-04-01.