### PR TITLE
docs: add donation_id to Grant and UnintegratedGrant schemas (ENG-2217)

### DIFF
--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -3697,6 +3697,11 @@ components:
           type: string
           description: ID of the grant associated with the donor advised fund
           example: 897823sdjf8sfjs
+        donation_id:
+          type: string
+          readOnly: true
+          description: The ID of the donation initiated by this grant, if one exists.
+          example: donation_01j8rs605a4gctmbm58d87mvsj
         createdAt:
           type: string
           readOnly: true
@@ -3954,6 +3959,11 @@ components:
           readOnly: true
           description: The tracking ID for the unintegrated grant
           example: L9E182VBGP
+        donation_id:
+          type: string
+          readOnly: true
+          description: The ID of the donation initiated by this grant, if one exists.
+          example: donation_01j8rs605a4gctmbm58d87mvsj
         workflowSessionId:
           type: string
           readOnly: true

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -5079,6 +5079,11 @@ components:
           type: string
           description: ID of the grant associated with the donor advised fund
           example: 897823sdjf8sfjs
+        donation_id:
+          type: string
+          readOnly: true
+          description: The ID of the donation initiated by this grant, if one exists.
+          example: donation_01j8rs605a4gctmbm58d87mvsj
         createdAt:
           type: string
           readOnly: true
@@ -5341,6 +5346,11 @@ components:
           readOnly: true
           description: The tracking ID for the unintegrated grant
           example: L9E182VBGP
+        donation_id:
+          type: string
+          readOnly: true
+          description: The ID of the donation initiated by this grant, if one exists.
+          example: donation_01j8rs605a4gctmbm58d87mvsj
         workflowSessionId:
           type: string
           readOnly: true


### PR DESCRIPTION
## Summary

Documents the new `donation_id` field on the `Grant` and `UnintegratedGrant` schemas, added to the API in chariot-giving/chariot#11154 (ENG-2217).

A partner who creates a DAFpay grant can now go directly from that grant to the donation it initiated — `donation_id` is the donation's id (a `donation_...` CUID), looked up via the grant's initiation.

## Changes

Added an optional, read-only `donation_id` to `Grant` and `UnintegratedGrant` in both active spec versions:
- `specs/2026-04-01.yaml`
- `specs/2026-01-15.yaml`

The field is present only when the grant initiated a donation.

## Companion PR

API change: chariot-giving/chariot#11154
