### PR TITLE
docs: document recipient_name on disbursement transactions

### DIFF
--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -6418,6 +6418,11 @@ components:
                 description: "A note to the recipient. Maximum length: 600 characters."
                 maxLength: 600
                 example: "Allocate to education"
+              recipient_name:
+                type: string
+                description: "The intended recipient of the grant (for example, a fiscal sponsor's project). Maximum length: 255 characters."
+                maxLength: 255
+                example: "Clean Water Project"
               donors:
                 $ref: "#/components/schemas/TransactionDonors"
               daf_grant:
@@ -6538,6 +6543,11 @@ components:
           description: "A note to the recipient."
           nullable: true
           example: "Allocate to education"
+        recipient_name:
+          type: string
+          description: "The intended recipient of the grant (for example, a fiscal sponsor's project)."
+          nullable: true
+          example: "Clean Water Project"
         donors:
           $ref: "#/components/schemas/TransactionDonors"
         daf_grant:


### PR DESCRIPTION
## Summary

Documents the new optional `recipient_name` field on disbursement transactions for the disbursements API. It names the intended recipient of a grant — for example, a specific project when disbursing to a fiscal sponsor.

Implements the docs side of ENG-3593 (API change: chariot-giving/chariot#11218).

## Changes

`specs/2026-04-01.yaml` — added `recipient_name` to:
- the `CreateDisbursementInput` transaction schema (create request; `maxLength: 255`)
- the `Transaction` response schema (returned by GET/List disbursements)

Added to the current spec only, since it's a newly available field. `fern check` passes (0 errors).
