### PR TITLE
fix(openapi): standardize API errors on RFC 7807 problem+json (ENG-3996)

### DIFF
--- a/fern/versions/v2023-01-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2023-01-01/pages/api/errors-1.mdx
@@ -37,5 +37,5 @@ The fields are:
 
 - `type` — a URI reference identifying the problem type (currently always `about:blank`).
 - `title` — a short, constant summary (`API Error`).
-- `status` — the integer HTTP status code. This is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`); only parse a response body as a resource on a 2xx status.
+- `status` — the integer HTTP status code.
 - `detail` — a human-readable explanation specific to this error.

--- a/fern/versions/v2023-01-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2023-01-01/pages/api/errors-1.mdx
@@ -22,11 +22,11 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-The Chariot API returns one of two error body formats depending on the endpoint. Both carry an `X-Request-Id` response header you can quote when contacting support.
+The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
 
-## Resource and DAFpay endpoints
+## Problem details (`application/problem+json`)
 
-Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object with the media type `application/problem+json`. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
 
 ```json Problem Details
 {
@@ -37,9 +37,9 @@ Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rf
 }
 ```
 
-## Grantmaker read and query endpoints
+## Connect errors (`application/json`)
 
-The grantmaker read and query endpoints are served over Connect (gRPC) and return a JSON body whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
 
 ```json Connect Error
 {
@@ -58,7 +58,7 @@ The grantmaker read and query endpoints are served over Connect (gRPC) and retur
 }
 ```
 
-The Connect `code` string maps to the HTTP status as follows.
+For this format, the `code` string maps to the HTTP status as follows.
 
 | HTTP status | Connect code          |
 | :---------- | :-------------------- |
@@ -67,6 +67,5 @@ The Connect `code` string maps to the HTTP status as follows.
 | 403         | `permission_denied`   |
 | 404         | `not_found`           |
 | 409         | `aborted`             |
-| 410         | `not_found`           |
 | 412         | `failed_precondition` |
 | 500         | `internal`            |

--- a/fern/versions/v2023-01-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2023-01-01/pages/api/errors-1.mdx
@@ -24,9 +24,9 @@ The Chariot API uses standard HTTP status response codes
 
 The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
 
-## Problem details (`application/problem+json`)
+## RFC 7807 problem details
 
-An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, returned with the `application/problem+json` media type. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
 
 ```json Problem Details
 {
@@ -37,9 +37,9 @@ An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. Th
 }
 ```
 
-## Connect errors (`application/json`)
+## Connect (gRPC) errors
 
-A Connect (gRPC) error whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
 
 ```json Connect Error
 {

--- a/fern/versions/v2023-01-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2023-01-01/pages/api/errors-1.mdx
@@ -22,40 +22,20 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
-
-## RFC 7807 problem details
-
-An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, returned with the `application/problem+json` media type. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+All error responses use the [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details format, returned with the `application/problem+json` media type. Every error response includes an `X-Request-Id` header you can quote when contacting support.
 
 ```json Problem Details
 {
   "type": "about:blank",
-  "title": "Bad Request",
+  "title": "API Error",
   "status": 400,
   "detail": "The request is invalid or contains invalid parameters."
 }
 ```
 
-## Connect (gRPC) errors
+The fields are:
 
-A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The request id is returned in the `X-Request-Id` response header.
-
-```json Connect Error
-{
-  "code": "invalid_argument",
-  "message": "The request is invalid or contains invalid parameters."
-}
-```
-
-For this format, the `code` string maps to the HTTP status as follows.
-
-| HTTP status | Connect code          |
-| :---------- | :-------------------- |
-| 400         | `invalid_argument`    |
-| 401         | `unauthenticated`     |
-| 403         | `permission_denied`   |
-| 404         | `not_found`           |
-| 409         | `aborted`             |
-| 412         | `failed_precondition` |
-| 500         | `internal`            |
+- `type` — a URI reference identifying the problem type (currently always `about:blank`).
+- `title` — a short, constant summary (`API Error`).
+- `status` — the integer HTTP status code. This is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`); only parse a response body as a resource on a 2xx status.
+- `detail` — a human-readable explanation specific to this error.

--- a/fern/versions/v2023-01-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2023-01-01/pages/api/errors-1.mdx
@@ -22,15 +22,51 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-<Aside>
-  All error responses come with the following standard shape.
+The Chariot API returns one of two error body formats depending on the endpoint. Both carry an `X-Request-Id` response header you can quote when contacting support.
 
-  ```json Error Response
-  {
-    "timestamp": "2020-07-10 15:00:00.000",
-    "code": 400,
-    "error" : "Bad Request",
-    "message": "a descriptive, yet terse snippet explaining what went wrong"
-  }
-  ```
-</Aside>
+## Resource and DAFpay endpoints
+
+Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object with the media type `application/problem+json`. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+
+```json Problem Details
+{
+  "type": "about:blank",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The request is invalid or contains invalid parameters."
+}
+```
+
+## Grantmaker read and query endpoints
+
+The grantmaker read and query endpoints are served over Connect (gRPC) and return a JSON body whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+
+```json Connect Error
+{
+  "code": "invalid_argument",
+  "message": "The request is invalid or contains invalid parameters.",
+  "details": [
+    {
+      "type": "google.rpc.ErrorInfo",
+      "debug": {
+        "metadata": {
+          "X-Request-ID": "2d46f73e-24b6-43c6-bcbd-fa22415f697a"
+        }
+      }
+    }
+  ]
+}
+```
+
+The Connect `code` string maps to the HTTP status as follows.
+
+| HTTP status | Connect code          |
+| :---------- | :-------------------- |
+| 400         | `invalid_argument`    |
+| 401         | `unauthenticated`     |
+| 403         | `permission_denied`   |
+| 404         | `not_found`           |
+| 409         | `aborted`             |
+| 410         | `not_found`           |
+| 412         | `failed_precondition` |
+| 500         | `internal`            |

--- a/fern/versions/v2023-01-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2023-01-01/pages/api/errors-1.mdx
@@ -39,22 +39,12 @@ An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, re
 
 ## Connect (gRPC) errors
 
-A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The request id is returned in the `X-Request-Id` response header.
 
 ```json Connect Error
 {
   "code": "invalid_argument",
-  "message": "The request is invalid or contains invalid parameters.",
-  "details": [
-    {
-      "type": "google.rpc.ErrorInfo",
-      "debug": {
-        "metadata": {
-          "X-Request-ID": "2d46f73e-24b6-43c6-bcbd-fa22415f697a"
-        }
-      }
-    }
-  ]
+  "message": "The request is invalid or contains invalid parameters."
 }
 ```
 

--- a/fern/versions/v2025-02-24/pages/api/errors-1.mdx
+++ b/fern/versions/v2025-02-24/pages/api/errors-1.mdx
@@ -37,5 +37,5 @@ The fields are:
 
 - `type` — a URI reference identifying the problem type (currently always `about:blank`).
 - `title` — a short, constant summary (`API Error`).
-- `status` — the integer HTTP status code. This is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`); only parse a response body as a resource on a 2xx status.
+- `status` — the integer HTTP status code.
 - `detail` — a human-readable explanation specific to this error.

--- a/fern/versions/v2025-02-24/pages/api/errors-1.mdx
+++ b/fern/versions/v2025-02-24/pages/api/errors-1.mdx
@@ -22,11 +22,11 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-The Chariot API returns one of two error body formats depending on the endpoint. Both carry an `X-Request-Id` response header you can quote when contacting support.
+The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
 
-## Resource and DAFpay endpoints
+## Problem details (`application/problem+json`)
 
-Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object with the media type `application/problem+json`. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
 
 ```json Problem Details
 {
@@ -37,9 +37,9 @@ Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rf
 }
 ```
 
-## Grantmaker read and query endpoints
+## Connect errors (`application/json`)
 
-The grantmaker read and query endpoints are served over Connect (gRPC) and return a JSON body whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
 
 ```json Connect Error
 {
@@ -58,7 +58,7 @@ The grantmaker read and query endpoints are served over Connect (gRPC) and retur
 }
 ```
 
-The Connect `code` string maps to the HTTP status as follows.
+For this format, the `code` string maps to the HTTP status as follows.
 
 | HTTP status | Connect code          |
 | :---------- | :-------------------- |
@@ -67,6 +67,5 @@ The Connect `code` string maps to the HTTP status as follows.
 | 403         | `permission_denied`   |
 | 404         | `not_found`           |
 | 409         | `aborted`             |
-| 410         | `not_found`           |
 | 412         | `failed_precondition` |
 | 500         | `internal`            |

--- a/fern/versions/v2025-02-24/pages/api/errors-1.mdx
+++ b/fern/versions/v2025-02-24/pages/api/errors-1.mdx
@@ -24,9 +24,9 @@ The Chariot API uses standard HTTP status response codes
 
 The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
 
-## Problem details (`application/problem+json`)
+## RFC 7807 problem details
 
-An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, returned with the `application/problem+json` media type. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
 
 ```json Problem Details
 {
@@ -37,9 +37,9 @@ An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. Th
 }
 ```
 
-## Connect errors (`application/json`)
+## Connect (gRPC) errors
 
-A Connect (gRPC) error whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
 
 ```json Connect Error
 {

--- a/fern/versions/v2025-02-24/pages/api/errors-1.mdx
+++ b/fern/versions/v2025-02-24/pages/api/errors-1.mdx
@@ -22,40 +22,20 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
-
-## RFC 7807 problem details
-
-An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, returned with the `application/problem+json` media type. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+All error responses use the [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details format, returned with the `application/problem+json` media type. Every error response includes an `X-Request-Id` header you can quote when contacting support.
 
 ```json Problem Details
 {
   "type": "about:blank",
-  "title": "Bad Request",
+  "title": "API Error",
   "status": 400,
   "detail": "The request is invalid or contains invalid parameters."
 }
 ```
 
-## Connect (gRPC) errors
+The fields are:
 
-A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The request id is returned in the `X-Request-Id` response header.
-
-```json Connect Error
-{
-  "code": "invalid_argument",
-  "message": "The request is invalid or contains invalid parameters."
-}
-```
-
-For this format, the `code` string maps to the HTTP status as follows.
-
-| HTTP status | Connect code          |
-| :---------- | :-------------------- |
-| 400         | `invalid_argument`    |
-| 401         | `unauthenticated`     |
-| 403         | `permission_denied`   |
-| 404         | `not_found`           |
-| 409         | `aborted`             |
-| 412         | `failed_precondition` |
-| 500         | `internal`            |
+- `type` — a URI reference identifying the problem type (currently always `about:blank`).
+- `title` — a short, constant summary (`API Error`).
+- `status` — the integer HTTP status code. This is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`); only parse a response body as a resource on a 2xx status.
+- `detail` — a human-readable explanation specific to this error.

--- a/fern/versions/v2025-02-24/pages/api/errors-1.mdx
+++ b/fern/versions/v2025-02-24/pages/api/errors-1.mdx
@@ -22,15 +22,51 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-<Aside>
-  All error responses come with the following standard shape.
+The Chariot API returns one of two error body formats depending on the endpoint. Both carry an `X-Request-Id` response header you can quote when contacting support.
 
-  ```json Error Response
-  {
-    "timestamp": "2020-07-10 15:00:00.000",
-    "code": 400,
-    "error" : "Bad Request",
-    "message": "a descriptive, yet terse snippet explaining what went wrong"
-  }
-  ```
-</Aside>
+## Resource and DAFpay endpoints
+
+Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object with the media type `application/problem+json`. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+
+```json Problem Details
+{
+  "type": "about:blank",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The request is invalid or contains invalid parameters."
+}
+```
+
+## Grantmaker read and query endpoints
+
+The grantmaker read and query endpoints are served over Connect (gRPC) and return a JSON body whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+
+```json Connect Error
+{
+  "code": "invalid_argument",
+  "message": "The request is invalid or contains invalid parameters.",
+  "details": [
+    {
+      "type": "google.rpc.ErrorInfo",
+      "debug": {
+        "metadata": {
+          "X-Request-ID": "2d46f73e-24b6-43c6-bcbd-fa22415f697a"
+        }
+      }
+    }
+  ]
+}
+```
+
+The Connect `code` string maps to the HTTP status as follows.
+
+| HTTP status | Connect code          |
+| :---------- | :-------------------- |
+| 400         | `invalid_argument`    |
+| 401         | `unauthenticated`     |
+| 403         | `permission_denied`   |
+| 404         | `not_found`           |
+| 409         | `aborted`             |
+| 410         | `not_found`           |
+| 412         | `failed_precondition` |
+| 500         | `internal`            |

--- a/fern/versions/v2025-02-24/pages/api/errors-1.mdx
+++ b/fern/versions/v2025-02-24/pages/api/errors-1.mdx
@@ -39,22 +39,12 @@ An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, re
 
 ## Connect (gRPC) errors
 
-A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The request id is returned in the `X-Request-Id` response header.
 
 ```json Connect Error
 {
   "code": "invalid_argument",
-  "message": "The request is invalid or contains invalid parameters.",
-  "details": [
-    {
-      "type": "google.rpc.ErrorInfo",
-      "debug": {
-        "metadata": {
-          "X-Request-ID": "2d46f73e-24b6-43c6-bcbd-fa22415f697a"
-        }
-      }
-    }
-  ]
+  "message": "The request is invalid or contains invalid parameters."
 }
 ```
 

--- a/fern/versions/v2026-01-15/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-01-15/pages/api/errors-1.mdx
@@ -37,5 +37,5 @@ The fields are:
 
 - `type` — a URI reference identifying the problem type (currently always `about:blank`).
 - `title` — a short, constant summary (`API Error`).
-- `status` — the integer HTTP status code. This is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`); only parse a response body as a resource on a 2xx status.
+- `status` — the integer HTTP status code.
 - `detail` — a human-readable explanation specific to this error.

--- a/fern/versions/v2026-01-15/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-01-15/pages/api/errors-1.mdx
@@ -22,11 +22,11 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-The Chariot API returns one of two error body formats depending on the endpoint. Both carry an `X-Request-Id` response header you can quote when contacting support.
+The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
 
-## Resource and DAFpay endpoints
+## Problem details (`application/problem+json`)
 
-Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object with the media type `application/problem+json`. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
 
 ```json Problem Details
 {
@@ -37,9 +37,9 @@ Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rf
 }
 ```
 
-## Grantmaker read and query endpoints
+## Connect errors (`application/json`)
 
-The grantmaker read and query endpoints are served over Connect (gRPC) and return a JSON body whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
 
 ```json Connect Error
 {
@@ -58,7 +58,7 @@ The grantmaker read and query endpoints are served over Connect (gRPC) and retur
 }
 ```
 
-The Connect `code` string maps to the HTTP status as follows.
+For this format, the `code` string maps to the HTTP status as follows.
 
 | HTTP status | Connect code          |
 | :---------- | :-------------------- |
@@ -67,6 +67,5 @@ The Connect `code` string maps to the HTTP status as follows.
 | 403         | `permission_denied`   |
 | 404         | `not_found`           |
 | 409         | `aborted`             |
-| 410         | `not_found`           |
 | 412         | `failed_precondition` |
 | 500         | `internal`            |

--- a/fern/versions/v2026-01-15/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-01-15/pages/api/errors-1.mdx
@@ -24,9 +24,9 @@ The Chariot API uses standard HTTP status response codes
 
 The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
 
-## Problem details (`application/problem+json`)
+## RFC 7807 problem details
 
-An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, returned with the `application/problem+json` media type. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
 
 ```json Problem Details
 {
@@ -37,9 +37,9 @@ An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. Th
 }
 ```
 
-## Connect errors (`application/json`)
+## Connect (gRPC) errors
 
-A Connect (gRPC) error whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
 
 ```json Connect Error
 {

--- a/fern/versions/v2026-01-15/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-01-15/pages/api/errors-1.mdx
@@ -22,40 +22,20 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
-
-## RFC 7807 problem details
-
-An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, returned with the `application/problem+json` media type. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+All error responses use the [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details format, returned with the `application/problem+json` media type. Every error response includes an `X-Request-Id` header you can quote when contacting support.
 
 ```json Problem Details
 {
   "type": "about:blank",
-  "title": "Bad Request",
+  "title": "API Error",
   "status": 400,
   "detail": "The request is invalid or contains invalid parameters."
 }
 ```
 
-## Connect (gRPC) errors
+The fields are:
 
-A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The request id is returned in the `X-Request-Id` response header.
-
-```json Connect Error
-{
-  "code": "invalid_argument",
-  "message": "The request is invalid or contains invalid parameters."
-}
-```
-
-For this format, the `code` string maps to the HTTP status as follows.
-
-| HTTP status | Connect code          |
-| :---------- | :-------------------- |
-| 400         | `invalid_argument`    |
-| 401         | `unauthenticated`     |
-| 403         | `permission_denied`   |
-| 404         | `not_found`           |
-| 409         | `aborted`             |
-| 412         | `failed_precondition` |
-| 500         | `internal`            |
+- `type` — a URI reference identifying the problem type (currently always `about:blank`).
+- `title` — a short, constant summary (`API Error`).
+- `status` — the integer HTTP status code. This is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`); only parse a response body as a resource on a 2xx status.
+- `detail` — a human-readable explanation specific to this error.

--- a/fern/versions/v2026-01-15/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-01-15/pages/api/errors-1.mdx
@@ -22,15 +22,51 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-<Aside>
-  All error responses come with the following standard shape.
+The Chariot API returns one of two error body formats depending on the endpoint. Both carry an `X-Request-Id` response header you can quote when contacting support.
 
-  ```json Error Response
-  {
-    "timestamp": "2020-07-10 15:00:00.000",
-    "code": 400,
-    "error" : "Bad Request",
-    "message": "a descriptive, yet terse snippet explaining what went wrong"
-  }
-  ```
-</Aside>
+## Resource and DAFpay endpoints
+
+Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object with the media type `application/problem+json`. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+
+```json Problem Details
+{
+  "type": "about:blank",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The request is invalid or contains invalid parameters."
+}
+```
+
+## Grantmaker read and query endpoints
+
+The grantmaker read and query endpoints are served over Connect (gRPC) and return a JSON body whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+
+```json Connect Error
+{
+  "code": "invalid_argument",
+  "message": "The request is invalid or contains invalid parameters.",
+  "details": [
+    {
+      "type": "google.rpc.ErrorInfo",
+      "debug": {
+        "metadata": {
+          "X-Request-ID": "2d46f73e-24b6-43c6-bcbd-fa22415f697a"
+        }
+      }
+    }
+  ]
+}
+```
+
+The Connect `code` string maps to the HTTP status as follows.
+
+| HTTP status | Connect code          |
+| :---------- | :-------------------- |
+| 400         | `invalid_argument`    |
+| 401         | `unauthenticated`     |
+| 403         | `permission_denied`   |
+| 404         | `not_found`           |
+| 409         | `aborted`             |
+| 410         | `not_found`           |
+| 412         | `failed_precondition` |
+| 500         | `internal`            |

--- a/fern/versions/v2026-01-15/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-01-15/pages/api/errors-1.mdx
@@ -39,22 +39,12 @@ An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, re
 
 ## Connect (gRPC) errors
 
-A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The request id is returned in the `X-Request-Id` response header.
 
 ```json Connect Error
 {
   "code": "invalid_argument",
-  "message": "The request is invalid or contains invalid parameters.",
-  "details": [
-    {
-      "type": "google.rpc.ErrorInfo",
-      "debug": {
-        "metadata": {
-          "X-Request-ID": "2d46f73e-24b6-43c6-bcbd-fa22415f697a"
-        }
-      }
-    }
-  ]
+  "message": "The request is invalid or contains invalid parameters."
 }
 ```
 

--- a/fern/versions/v2026-04-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-04-01/pages/api/errors-1.mdx
@@ -37,5 +37,5 @@ The fields are:
 
 - `type` — a URI reference identifying the problem type (currently always `about:blank`).
 - `title` — a short, constant summary (`API Error`).
-- `status` — the integer HTTP status code. This is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`); only parse a response body as a resource on a 2xx status.
+- `status` — the integer HTTP status code.
 - `detail` — a human-readable explanation specific to this error.

--- a/fern/versions/v2026-04-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-04-01/pages/api/errors-1.mdx
@@ -22,11 +22,11 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-The Chariot API returns one of two error body formats depending on the endpoint. Both carry an `X-Request-Id` response header you can quote when contacting support.
+The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
 
-## Resource and DAFpay endpoints
+## Problem details (`application/problem+json`)
 
-Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object with the media type `application/problem+json`. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
 
 ```json Problem Details
 {
@@ -37,9 +37,9 @@ Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rf
 }
 ```
 
-## Grantmaker read and query endpoints
+## Connect errors (`application/json`)
 
-The grantmaker read and query endpoints are served over Connect (gRPC) and return a JSON body whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
 
 ```json Connect Error
 {
@@ -58,7 +58,7 @@ The grantmaker read and query endpoints are served over Connect (gRPC) and retur
 }
 ```
 
-The Connect `code` string maps to the HTTP status as follows.
+For this format, the `code` string maps to the HTTP status as follows.
 
 | HTTP status | Connect code          |
 | :---------- | :-------------------- |
@@ -67,6 +67,5 @@ The Connect `code` string maps to the HTTP status as follows.
 | 403         | `permission_denied`   |
 | 404         | `not_found`           |
 | 409         | `aborted`             |
-| 410         | `not_found`           |
 | 412         | `failed_precondition` |
 | 500         | `internal`            |

--- a/fern/versions/v2026-04-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-04-01/pages/api/errors-1.mdx
@@ -24,9 +24,9 @@ The Chariot API uses standard HTTP status response codes
 
 The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
 
-## Problem details (`application/problem+json`)
+## RFC 7807 problem details
 
-An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, returned with the `application/problem+json` media type. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
 
 ```json Problem Details
 {
@@ -37,9 +37,9 @@ An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object. Th
 }
 ```
 
-## Connect errors (`application/json`)
+## Connect (gRPC) errors
 
-A Connect (gRPC) error whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
 
 ```json Connect Error
 {

--- a/fern/versions/v2026-04-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-04-01/pages/api/errors-1.mdx
@@ -22,40 +22,20 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-The Chariot API returns errors in one of two body formats. The exact format for a given operation is shown in that operation's response examples in the API Reference. Both formats include an `X-Request-Id` response header you can quote when contacting support.
-
-## RFC 7807 problem details
-
-An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, returned with the `application/problem+json` media type. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+All error responses use the [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details format, returned with the `application/problem+json` media type. Every error response includes an `X-Request-Id` header you can quote when contacting support.
 
 ```json Problem Details
 {
   "type": "about:blank",
-  "title": "Bad Request",
+  "title": "API Error",
   "status": 400,
   "detail": "The request is invalid or contains invalid parameters."
 }
 ```
 
-## Connect (gRPC) errors
+The fields are:
 
-A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The request id is returned in the `X-Request-Id` response header.
-
-```json Connect Error
-{
-  "code": "invalid_argument",
-  "message": "The request is invalid or contains invalid parameters."
-}
-```
-
-For this format, the `code` string maps to the HTTP status as follows.
-
-| HTTP status | Connect code          |
-| :---------- | :-------------------- |
-| 400         | `invalid_argument`    |
-| 401         | `unauthenticated`     |
-| 403         | `permission_denied`   |
-| 404         | `not_found`           |
-| 409         | `aborted`             |
-| 412         | `failed_precondition` |
-| 500         | `internal`            |
+- `type` — a URI reference identifying the problem type (currently always `about:blank`).
+- `title` — a short, constant summary (`API Error`).
+- `status` — the integer HTTP status code. This is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`); only parse a response body as a resource on a 2xx status.
+- `detail` — a human-readable explanation specific to this error.

--- a/fern/versions/v2026-04-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-04-01/pages/api/errors-1.mdx
@@ -22,15 +22,51 @@ The Chariot API uses standard HTTP status response codes
 | 502  | Bad Gateway: The server received an invalid response from an upstream server.                                                                                                             |
 | 503  | Service Unavailable: The server is not ready to handle the request.                                                                                                                       |
 
-<Aside>
-  All error responses come with the following standard shape.
+The Chariot API returns one of two error body formats depending on the endpoint. Both carry an `X-Request-Id` response header you can quote when contacting support.
 
-  ```json Error Response
-  {
-    "timestamp": "2020-07-10 15:00:00.000",
-    "code": 400,
-    "error" : "Bad Request",
-    "message": "a descriptive, yet terse snippet explaining what went wrong"
-  }
-  ```
-</Aside>
+## Resource and DAFpay endpoints
+
+Resource and DAFpay endpoints return an [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object with the media type `application/problem+json`. The `status` field is the integer HTTP status code; it is unrelated to a resource's own `status` string (e.g. a grant's `"Initiated"`).
+
+```json Problem Details
+{
+  "type": "about:blank",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The request is invalid or contains invalid parameters."
+}
+```
+
+## Grantmaker read and query endpoints
+
+The grantmaker read and query endpoints are served over Connect (gRPC) and return a JSON body whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+
+```json Connect Error
+{
+  "code": "invalid_argument",
+  "message": "The request is invalid or contains invalid parameters.",
+  "details": [
+    {
+      "type": "google.rpc.ErrorInfo",
+      "debug": {
+        "metadata": {
+          "X-Request-ID": "2d46f73e-24b6-43c6-bcbd-fa22415f697a"
+        }
+      }
+    }
+  ]
+}
+```
+
+The Connect `code` string maps to the HTTP status as follows.
+
+| HTTP status | Connect code          |
+| :---------- | :-------------------- |
+| 400         | `invalid_argument`    |
+| 401         | `unauthenticated`     |
+| 403         | `permission_denied`   |
+| 404         | `not_found`           |
+| 409         | `aborted`             |
+| 410         | `not_found`           |
+| 412         | `failed_precondition` |
+| 500         | `internal`            |

--- a/fern/versions/v2026-04-01/pages/api/errors-1.mdx
+++ b/fern/versions/v2026-04-01/pages/api/errors-1.mdx
@@ -39,22 +39,12 @@ An [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem-details object, re
 
 ## Connect (gRPC) errors
 
-A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The optional `details` array carries structured entries such as `google.rpc.ErrorInfo`, which may include the request id.
+A Connect (gRPC) error, returned with the `application/json` media type, whose `code` is a machine-readable **string** (not a number). The request id is returned in the `X-Request-Id` response header.
 
 ```json Connect Error
 {
   "code": "invalid_argument",
-  "message": "The request is invalid or contains invalid parameters.",
-  "details": [
-    {
-      "type": "google.rpc.ErrorInfo",
-      "debug": {
-        "metadata": {
-          "X-Request-ID": "2d46f73e-24b6-43c6-bcbd-fa22415f697a"
-        }
-      }
-    }
-  ]
+  "message": "The request is invalid or contains invalid parameters."
 }
 ```
 

--- a/specs/2023-01-01.yaml
+++ b/specs/2023-01-01.yaml
@@ -1814,10 +1814,10 @@ components:
     ProblemDetails:
       type: object
       description: >-
-        RFC 7807 problem-details error (media type application/problem+json),
-        returned by resource and DAFpay endpoints. The `status` field is an
-        integer HTTP status code; it is unrelated to a resource's `status`
-        string (e.g. a grant's "Initiated"). Parse a body as a resource only on 2xx.
+        RFC 7807 problem-details error (media type application/problem+json).
+        The `status` field is an integer HTTP status code; it is unrelated to a
+        resource's `status` string (e.g. a grant's "Initiated"). Parse a body as
+        a resource only on 2xx.
       required:
         - type
         - title
@@ -1848,8 +1848,8 @@ components:
     ConnectError:
       type: object
       description: >-
-        Connect (gRPC) error returned by the grantmaker read and query endpoints.
-        The `code` field is a machine-readable string code (not a number).
+        Connect (gRPC) error format. The `code` field is a machine-readable
+        string code (not a number).
       required:
         - code
         - message
@@ -1862,30 +1862,9 @@ components:
           type: string
           description: A human-readable description of the error.
           example: The request was invalid.
-        details:
-          type: array
-          description: Optional structured error details (e.g. google.rpc.ErrorInfo entries carrying the request id).
-          items:
-            type: object
-            properties:
-              type:
-                type: string
-                description: The fully-qualified type of the detail entry.
-                example: google.rpc.ErrorInfo
-              value:
-                type: string
-                description: Base64-encoded protobuf payload for the detail entry.
-              debug:
-                type: object
-                description: Human-readable debug metadata (omitted in production).
       example:
         code: invalid_argument
         message: The request is invalid or contains invalid parameters.
-        details:
-          - type: google.rpc.ErrorInfo
-            debug:
-              metadata:
-                X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -2478,11 +2457,6 @@ components:
               value:
                 code: invalid_argument
                 message: "The request is invalid or contains invalid parameters."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -2497,11 +2471,6 @@ components:
               value:
                 code: unauthenticated
                 message: "Authentication credentials were missing or invalid."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectForbiddenError:
       description: Access denied
       headers:
@@ -2516,11 +2485,6 @@ components:
               value:
                 code: permission_denied
                 message: "You do not have permission to access this resource."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectNotFoundError:
       description: Resource Not Found
       headers:
@@ -2535,11 +2499,6 @@ components:
               value:
                 code: not_found
                 message: "The requested resource was not found."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectConflictError:
       description: Resource Conflicts
       headers:
@@ -2554,11 +2513,6 @@ components:
               value:
                 code: aborted
                 message: "The request conflicts with the current state of the resource."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectGoneError:
       description: Resource Gone or Expired
       headers:
@@ -2573,11 +2527,6 @@ components:
               value:
                 code: not_found
                 message: "The resource is no longer available."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -2592,11 +2541,6 @@ components:
               value:
                 code: failed_precondition
                 message: "A precondition for the request was not met."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectInternalServerError:
       description: Internal Server Error
       headers:
@@ -2611,11 +2555,6 @@ components:
               value:
                 code: internal
                 message: "The server encountered an error processing your request."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2023-01-01.yaml
+++ b/specs/2023-01-01.yaml
@@ -2396,11 +2396,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Bad Request"
-            status: 400
-            detail: "The request is invalid or contains invalid parameters."
+          examples:
+            BadRequest:
+              value:
+                type: about:blank
+                title: "Bad Request"
+                status: 400
+                detail: "The request is invalid or contains invalid parameters."
     AuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -2410,11 +2412,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Unauthorized"
-            status: 401
-            detail: "Authentication credentials were missing or invalid."
+          examples:
+            Unauthorized:
+              value:
+                type: about:blank
+                title: "Unauthorized"
+                status: 401
+                detail: "Authentication credentials were missing or invalid."
     ForbiddenError:
       description: Access denied
       headers:
@@ -2424,11 +2428,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Forbidden"
-            status: 403
-            detail: "You do not have permission to access this resource."
+          examples:
+            Forbidden:
+              value:
+                type: about:blank
+                title: "Forbidden"
+                status: 403
+                detail: "You do not have permission to access this resource."
     NotFoundError:
       description: Resource Not Found
       headers:
@@ -2438,11 +2444,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Not Found"
-            status: 404
-            detail: "The requested resource was not found."
+          examples:
+            NotFound:
+              value:
+                type: about:blank
+                title: "Not Found"
+                status: 404
+                detail: "The requested resource was not found."
     ConflictError:
       description: Resource Conflicts
       headers:
@@ -2452,11 +2460,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Conflict"
-            status: 409
-            detail: "The request conflicts with the current state of the resource."
+          examples:
+            Conflict:
+              value:
+                type: about:blank
+                title: "Conflict"
+                status: 409
+                detail: "The request conflicts with the current state of the resource."
     GoneError:
       description: Resource Gone or Expired
       headers:
@@ -2466,11 +2476,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Gone"
-            status: 410
-            detail: "The resource is no longer available."
+          examples:
+            Gone:
+              value:
+                type: about:blank
+                title: "Gone"
+                status: 410
+                detail: "The resource is no longer available."
     PreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -2480,11 +2492,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Precondition Failed"
-            status: 412
-            detail: "A precondition for the request was not met."
+          examples:
+            PreconditionFailed:
+              value:
+                type: about:blank
+                title: "Precondition Failed"
+                status: 412
+                detail: "A precondition for the request was not met."
     InternalServerError:
       description: Internal Server Error
       headers:
@@ -2494,11 +2508,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Internal server error"
-            status: 500
-            detail: "The server encountered an error processing your request."
+          examples:
+            InternalServerError:
+              value:
+                type: about:blank
+                title: "Internal server error"
+                status: 500
+                detail: "The server encountered an error processing your request."
     ConnectBadRequestError:
       description: The request is invalid or contains invalid parameters
       headers:
@@ -2508,9 +2524,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: invalid_argument
-            message: "The request is invalid or contains invalid parameters."
+          examples:
+            BadRequest:
+              value:
+                code: invalid_argument
+                message: "The request is invalid or contains invalid parameters."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -2520,9 +2543,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: unauthenticated
-            message: "Authentication credentials were missing or invalid."
+          examples:
+            Unauthorized:
+              value:
+                code: unauthenticated
+                message: "Authentication credentials were missing or invalid."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectForbiddenError:
       description: Access denied
       headers:
@@ -2532,9 +2562,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: permission_denied
-            message: "You do not have permission to access this resource."
+          examples:
+            Forbidden:
+              value:
+                code: permission_denied
+                message: "You do not have permission to access this resource."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectNotFoundError:
       description: Resource Not Found
       headers:
@@ -2544,9 +2581,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: not_found
-            message: "The requested resource was not found."
+          examples:
+            NotFound:
+              value:
+                code: not_found
+                message: "The requested resource was not found."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectConflictError:
       description: Resource Conflicts
       headers:
@@ -2556,9 +2600,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: aborted
-            message: "The request conflicts with the current state of the resource."
+          examples:
+            Conflict:
+              value:
+                code: aborted
+                message: "The request conflicts with the current state of the resource."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectGoneError:
       description: Resource Gone or Expired
       headers:
@@ -2568,9 +2619,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: not_found
-            message: "The resource is no longer available."
+          examples:
+            Gone:
+              value:
+                code: not_found
+                message: "The resource is no longer available."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -2580,9 +2638,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: failed_precondition
-            message: "A precondition for the request was not met."
+          examples:
+            PreconditionFailed:
+              value:
+                code: failed_precondition
+                message: "A precondition for the request was not met."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectInternalServerError:
       description: Internal Server Error
       headers:
@@ -2592,9 +2657,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: internal
-            message: "The server encountered an error processing your request."
+          examples:
+            InternalServerError:
+              value:
+                code: internal
+                message: "The server encountered an error processing your request."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2023-01-01.yaml
+++ b/specs/2023-01-01.yaml
@@ -52,15 +52,15 @@ paths:
                 RedCross:
                   $ref: "#/components/examples/NonprofitRedCross"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/nonprofits:
     post:
       summary: Create nonprofit
@@ -109,17 +109,17 @@ paths:
               schema:
                 $ref: "#/components/schemas/Nonprofit"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "412":
-          $ref: "#/components/responses/ConnectPreconditionFailedError"
+          $ref: "#/components/responses/PreconditionFailedError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/nonprofits/{id}:
     get:
       summary: Get nonprofit
@@ -153,15 +153,15 @@ paths:
                 RedCross:
                   $ref: "#/components/examples/NonprofitRedCross"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/connects:
     post:
       summary: Create Connect
@@ -233,15 +233,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/ConnectOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/connects/{id}:
     get:
       summary: Get Connect
@@ -272,15 +272,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Connect"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/grants:
     get:
       summary: List Grants
@@ -316,13 +316,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Grant
       description: |-
@@ -413,15 +413,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     patch:
       summary: Update Grant
       description: |-
@@ -460,15 +460,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/recurring_grants:
     get:
       summary: List Recurring Grants
@@ -504,13 +504,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListRecurringGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Recurring Grant
       description: |-
@@ -601,15 +601,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/RecurringGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/unintegrated_grants:
     get:
       summary: List Unintegrated Grants
@@ -645,13 +645,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListUnintegratedGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/unintegrated_grants/{id}:
     get:
       summary: Get Unintegrated Grant
@@ -688,15 +688,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     patch:
       summary: Update Unintegrated Grant
       description: |-
@@ -735,15 +735,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/dafs:
     get:
       summary: List Donor Advised Funds
@@ -786,9 +786,9 @@ paths:
         "200":
           $ref: "#/components/responses/ListDafsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/dafs/{id}:
     get:
       summary: Get Donor Advised Fund
@@ -822,11 +822,11 @@ paths:
                 Npt:
                   $ref: "#/components/examples/DafOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/events:
     get:
       summary: List Events
@@ -863,13 +863,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/events/{id}:
     get:
       summary: Get Event
@@ -896,15 +896,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Event"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/event_subscriptions:
     post:
       summary: Create an Event Subscription
@@ -929,15 +929,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     get:
       summary: List Event Subscriptions
       description: |-
@@ -966,13 +966,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventSubscriptionsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/event_subscriptions/{id}:
     get:
       summary: Get an Event Subscription
@@ -999,15 +999,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     patch:
       summary: Update an Event Subscription
       description: |-
@@ -1035,15 +1035,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
 components:
   securitySchemes:
     auth0:
@@ -1831,7 +1831,7 @@ components:
         title:
           type: string
           description: A short, human-readable summary of the problem type.
-          example: Bad Request
+          example: API Error
         status:
           type: integer
           description: The HTTP status code for this error.
@@ -1842,29 +1842,9 @@ components:
           example: The request is invalid or contains invalid parameters.
       example:
         type: about:blank
-        title: Bad Request
+        title: "API Error"
         status: 400
         detail: The request is invalid or contains invalid parameters.
-    ConnectError:
-      type: object
-      description: >-
-        Connect (gRPC) error format. The `code` field is a machine-readable
-        string code (not a number).
-      required:
-        - code
-        - message
-      properties:
-        code:
-          type: string
-          description: The machine-readable Connect error code.
-          example: invalid_argument
-        message:
-          type: string
-          description: A human-readable description of the error.
-          example: The request was invalid.
-      example:
-        code: invalid_argument
-        message: The request is invalid or contains invalid parameters.
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -2328,7 +2308,7 @@ components:
             BadRequest:
               value:
                 type: about:blank
-                title: "Bad Request"
+                title: "API Error"
                 status: 400
                 detail: "The request is invalid or contains invalid parameters."
     AuthenticationError:
@@ -2344,7 +2324,7 @@ components:
             Unauthorized:
               value:
                 type: about:blank
-                title: "Unauthorized"
+                title: "API Error"
                 status: 401
                 detail: "Authentication credentials were missing or invalid."
     ForbiddenError:
@@ -2360,7 +2340,7 @@ components:
             Forbidden:
               value:
                 type: about:blank
-                title: "Forbidden"
+                title: "API Error"
                 status: 403
                 detail: "You do not have permission to access this resource."
     NotFoundError:
@@ -2376,7 +2356,7 @@ components:
             NotFound:
               value:
                 type: about:blank
-                title: "Not Found"
+                title: "API Error"
                 status: 404
                 detail: "The requested resource was not found."
     ConflictError:
@@ -2392,7 +2372,7 @@ components:
             Conflict:
               value:
                 type: about:blank
-                title: "Conflict"
+                title: "API Error"
                 status: 409
                 detail: "The request conflicts with the current state of the resource."
     GoneError:
@@ -2408,7 +2388,7 @@ components:
             Gone:
               value:
                 type: about:blank
-                title: "Gone"
+                title: "API Error"
                 status: 410
                 detail: "The resource is no longer available."
     PreconditionFailedError:
@@ -2424,7 +2404,7 @@ components:
             PreconditionFailed:
               value:
                 type: about:blank
-                title: "Precondition Failed"
+                title: "API Error"
                 status: 412
                 detail: "A precondition for the request was not met."
     InternalServerError:
@@ -2440,121 +2420,9 @@ components:
             InternalServerError:
               value:
                 type: about:blank
-                title: "Internal server error"
+                title: "API Error"
                 status: 500
                 detail: "The server encountered an error processing your request."
-    ConnectBadRequestError:
-      description: The request is invalid or contains invalid parameters
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            BadRequest:
-              value:
-                code: invalid_argument
-                message: "The request is invalid or contains invalid parameters."
-    ConnectAuthenticationError:
-      description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Unauthorized:
-              value:
-                code: unauthenticated
-                message: "Authentication credentials were missing or invalid."
-    ConnectForbiddenError:
-      description: Access denied
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Forbidden:
-              value:
-                code: permission_denied
-                message: "You do not have permission to access this resource."
-    ConnectNotFoundError:
-      description: Resource Not Found
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            NotFound:
-              value:
-                code: not_found
-                message: "The requested resource was not found."
-    ConnectConflictError:
-      description: Resource Conflicts
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Conflict:
-              value:
-                code: aborted
-                message: "The request conflicts with the current state of the resource."
-    ConnectGoneError:
-      description: Resource Gone or Expired
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Gone:
-              value:
-                code: not_found
-                message: "The resource is no longer available."
-    ConnectPreconditionFailedError:
-      description: Precondition Failed
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            PreconditionFailed:
-              value:
-                code: failed_precondition
-                message: "A precondition for the request was not met."
-    ConnectInternalServerError:
-      description: Internal Server Error
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            InternalServerError:
-              value:
-                code: internal
-                message: "The server encountered an error processing your request."
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2023-01-01.yaml
+++ b/specs/2023-01-01.yaml
@@ -1840,6 +1840,11 @@ components:
           type: string
           description: A human-readable explanation specific to this occurrence.
           example: The request is invalid or contains invalid parameters.
+      example:
+        type: about:blank
+        title: Bad Request
+        status: 400
+        detail: The request is invalid or contains invalid parameters.
     ConnectError:
       type: object
       description: >-
@@ -1859,9 +1864,28 @@ components:
           example: The request was invalid.
         details:
           type: array
-          description: Optional structured error details.
+          description: Optional structured error details (e.g. google.rpc.ErrorInfo entries carrying the request id).
           items:
             type: object
+            properties:
+              type:
+                type: string
+                description: The fully-qualified type of the detail entry.
+                example: google.rpc.ErrorInfo
+              value:
+                type: string
+                description: Base64-encoded protobuf payload for the detail entry.
+              debug:
+                type: object
+                description: Human-readable debug metadata (omitted in production).
+      example:
+        code: invalid_argument
+        message: The request is invalid or contains invalid parameters.
+        details:
+          - type: google.rpc.ErrorInfo
+            debug:
+              metadata:
+                X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   headers:
     X-Request-Id:
       description: The unique identifier for the request

--- a/specs/2023-01-01.yaml
+++ b/specs/2023-01-01.yaml
@@ -1815,9 +1815,7 @@ components:
       type: object
       description: >-
         RFC 7807 problem-details error (media type application/problem+json).
-        The `status` field is an integer HTTP status code; it is unrelated to a
-        resource's `status` string (e.g. a grant's "Initiated"). Parse a body as
-        a resource only on 2xx.
+        The `status` field is an integer HTTP status code.
       required:
         - type
         - title

--- a/specs/2023-01-01.yaml
+++ b/specs/2023-01-01.yaml
@@ -52,15 +52,15 @@ paths:
                 RedCross:
                   $ref: "#/components/examples/NonprofitRedCross"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/nonprofits:
     post:
       summary: Create nonprofit
@@ -109,17 +109,17 @@ paths:
               schema:
                 $ref: "#/components/schemas/Nonprofit"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "412":
-          $ref: "#/components/responses/PreconditionFailedError"
+          $ref: "#/components/responses/ConnectPreconditionFailedError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/nonprofits/{id}:
     get:
       summary: Get nonprofit
@@ -153,15 +153,15 @@ paths:
                 RedCross:
                   $ref: "#/components/examples/NonprofitRedCross"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/connects:
     post:
       summary: Create Connect
@@ -233,15 +233,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/ConnectOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/connects/{id}:
     get:
       summary: Get Connect
@@ -272,15 +272,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Connect"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/grants:
     get:
       summary: List Grants
@@ -316,13 +316,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     post:
       summary: Create Grant
       description: |-
@@ -413,15 +413,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     patch:
       summary: Update Grant
       description: |-
@@ -460,15 +460,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/recurring_grants:
     get:
       summary: List Recurring Grants
@@ -504,13 +504,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListRecurringGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     post:
       summary: Create Recurring Grant
       description: |-
@@ -601,15 +601,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/RecurringGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/unintegrated_grants:
     get:
       summary: List Unintegrated Grants
@@ -645,13 +645,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListUnintegratedGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/unintegrated_grants/{id}:
     get:
       summary: Get Unintegrated Grant
@@ -688,15 +688,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     patch:
       summary: Update Unintegrated Grant
       description: |-
@@ -735,15 +735,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/dafs:
     get:
       summary: List Donor Advised Funds
@@ -786,9 +786,9 @@ paths:
         "200":
           $ref: "#/components/responses/ListDafsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/dafs/{id}:
     get:
       summary: Get Donor Advised Fund
@@ -822,11 +822,11 @@ paths:
                 Npt:
                   $ref: "#/components/examples/DafOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/events:
     get:
       summary: List Events
@@ -863,13 +863,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/events/{id}:
     get:
       summary: Get Event
@@ -896,15 +896,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Event"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/event_subscriptions:
     post:
       summary: Create an Event Subscription
@@ -929,15 +929,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     get:
       summary: List Event Subscriptions
       description: |-
@@ -966,13 +966,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventSubscriptionsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/event_subscriptions/{id}:
     get:
       summary: Get an Event Subscription
@@ -999,15 +999,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     patch:
       summary: Update an Event Subscription
       description: |-
@@ -1035,15 +1035,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
 components:
   securitySchemes:
     auth0:
@@ -1811,30 +1811,57 @@ components:
           example: "https://example.com/webhook"
         category:
           $ref: "#/components/schemas/EventCategory"
-    Error:
+    ProblemDetails:
       type: object
+      description: >-
+        RFC 7807 problem-details error (media type application/problem+json),
+        returned by resource and DAFpay endpoints. The `status` field is an
+        integer HTTP status code; it is unrelated to a resource's `status`
+        string (e.g. a grant's "Initiated"). Parse a body as a resource only on 2xx.
       required:
-        - timestamp
+        - type
+        - title
+        - status
+        - detail
+      properties:
+        type:
+          type: string
+          description: A URI reference identifying the problem type.
+          example: about:blank
+        title:
+          type: string
+          description: A short, human-readable summary of the problem type.
+          example: Bad Request
+        status:
+          type: integer
+          description: The HTTP status code for this error.
+          example: 400
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence.
+          example: The request is invalid or contains invalid parameters.
+    ConnectError:
+      type: object
+      description: >-
+        Connect (gRPC) error returned by the grantmaker read and query endpoints.
+        The `code` field is a machine-readable string code (not a number).
+      required:
         - code
-        - error
         - message
       properties:
-        timestamp:
-          type: string
-          description: time when the error was reported. Expressed in RFC 3339 format.
-          example: "2020-01-31T23:00:00Z"
         code:
-          type: number
-          description: HTTP status code of the error
-          example: 400
-        error:
           type: string
-          description: A short name of the error; usually the HTTP status.
-          example: Bad Request
+          description: The machine-readable Connect error code.
+          example: invalid_argument
         message:
           type: string
-          description: The description of the error
-          example: Expected an API key to be provided in the header `x-chariot-api-key`
+          description: A human-readable description of the error.
+          example: The request was invalid.
+        details:
+          type: array
+          description: Optional structured error details.
+          items:
+            type: object
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -2342,15 +2369,125 @@ components:
         X-Request-Id:
           $ref: "#/components/headers/X-Request-Id"
       content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Bad Request"
+            status: 400
+            detail: "The request is invalid or contains invalid parameters."
+    AuthenticationError:
+      description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Unauthorized"
+            status: 401
+            detail: "Authentication credentials were missing or invalid."
+    ForbiddenError:
+      description: Access denied
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Forbidden"
+            status: 403
+            detail: "You do not have permission to access this resource."
+    NotFoundError:
+      description: Resource Not Found
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Not Found"
+            status: 404
+            detail: "The requested resource was not found."
+    ConflictError:
+      description: Resource Conflicts
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Conflict"
+            status: 409
+            detail: "The request conflicts with the current state of the resource."
+    GoneError:
+      description: Resource Gone or Expired
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Gone"
+            status: 410
+            detail: "The resource is no longer available."
+    PreconditionFailedError:
+      description: Precondition Failed
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Precondition Failed"
+            status: 412
+            detail: "A precondition for the request was not met."
+    InternalServerError:
+      description: Internal Server Error
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Internal server error"
+            status: 500
+            detail: "The server encountered an error processing your request."
+    ConnectBadRequestError:
+      description: The request is invalid or contains invalid parameters
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 400
-            error: "Bad Request"
-            message: "Expected an API key to be provided in the header `x-chariot-api-key`"
-    AuthenticationError:
+            code: invalid_argument
+            message: "The request is invalid or contains invalid parameters."
+    ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
         X-Request-Id:
@@ -2358,13 +2495,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 401
-            error: "Unauthorized"
-            message: "Unauthorized"
-    ForbiddenError:
+            code: unauthenticated
+            message: "Authentication credentials were missing or invalid."
+    ConnectForbiddenError:
       description: Access denied
       headers:
         X-Request-Id:
@@ -2372,13 +2507,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 403
-            error: "Forbidden"
-            message: "User is not allowed to access this resource"
-    NotFoundError:
+            code: permission_denied
+            message: "You do not have permission to access this resource."
+    ConnectNotFoundError:
       description: Resource Not Found
       headers:
         X-Request-Id:
@@ -2386,13 +2519,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 404
-            error: "Not Found"
-            message: "Resource is not found"
-    ConflictError:
+            code: not_found
+            message: "The requested resource was not found."
+    ConnectConflictError:
       description: Resource Conflicts
       headers:
         X-Request-Id:
@@ -2400,13 +2531,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 409
-            error: "Conflict"
-            message: "Request conflicts with an already existing resource"
-    GoneError:
+            code: aborted
+            message: "The request conflicts with the current state of the resource."
+    ConnectGoneError:
       description: Resource Gone or Expired
       headers:
         X-Request-Id:
@@ -2414,13 +2543,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 410
-            error: "Gone"
-            message: "The resource has expired"
-    PreconditionFailedError:
+            code: not_found
+            message: "The resource is no longer available."
+    ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
         X-Request-Id:
@@ -2428,13 +2555,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 412
-            error: "Precondition Failed"
-            message: "The requested action has a failed precondition"
-    InternalServerError:
+            code: failed_precondition
+            message: "A precondition for the request was not met."
+    ConnectInternalServerError:
       description: Internal Server Error
       headers:
         X-Request-Id:
@@ -2442,12 +2567,10 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 500
-            error: "Internal server error"
-            message: "The server encountered an error processing your request"
+            code: internal
+            message: "The server encountered an error processing your request."
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2023-01-01.yaml
+++ b/specs/2023-01-01.yaml
@@ -2194,34 +2194,19 @@ components:
                 type: string
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only substituting the pageToken with this value). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
-                    orgName: "National Philanthropic Trust"
-                    address: "123 Main St."
-                    address2: "Apt 100"
-                    city: "New York"
-                    state: "NY"
-                    zip: "12345"
-                    supported: true
-                    minimumGrantAmount: 5000
-                    institutionDown: false
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
-                    orgName: "National Philanthropic Trust"
-                    address: "123 Main St."
-                    address2: "Apt 100"
-                    city: "New York"
-                    state: "NY"
-                    zip: "12345"
-                    supported: true
-                    minimumGrantAmount: 5000
-                    institutionDown: false
+          example:
+            results:
+              - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
+                orgName: "National Philanthropic Trust"
+                address: "123 Main St."
+                address2: "Apt 100"
+                city: "New York"
+                state: "NY"
+                zip: "12345"
+                supported: true
+                minimumGrantAmount: 5000
+                institutionDown: false
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListGrantsResponse:
       description: The response for Grants.list
       headers:
@@ -2241,29 +2226,16 @@ components:
                 nullable: true
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the pageToken). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                    status: "Initiated"
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 20000
-                    status: "Received"
-                nextPageToken: null
+          example:
+            results:
+              - id: "1e60800e-849b-43d1-870e-57afc8d75473"
+                workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+                status: "Initiated"
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListRecurringGrantsResponse:
       description: The response for RecurringGrants.list
       headers:
@@ -2282,28 +2254,16 @@ components:
                 type: string
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the pageToken). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "29650c10-1eb3-4f97-a63e-f2e41c145b53"
-                    workflowSessionId: "b76fa69f-c554-43b2-af9a-1d4bb9a02016"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                    frequency: MONTHLY
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "579e2864-d65a-4a21-a056-1c91d0a95b5c"
-                    workflowSessionId: "ee27b65b-22f5-42fa-b966-0f83cac8fd2c"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 16:00:00.000"
-                    updatedAt: "2021-08-11 15:25:00.000"
-                    amount: 20000
-                    frequency: MONTHLY
+          example:
+            results:
+              - id: "29650c10-1eb3-4f97-a63e-f2e41c145b53"
+                workflowSessionId: "b76fa69f-c554-43b2-af9a-1d4bb9a02016"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+                frequency: MONTHLY
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListUnintegratedGrantsResponse:
       description: The response for UnintegratedGrants.list
       headers:
@@ -2325,26 +2285,15 @@ components:
                    to the same endpoint with the same parameters (only changing the pageToken). If
                    specified, then more results exist on the server that were not returned, otherwise
                    no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 20000
+          example:
+            results:
+              - id: "1e60800e-849b-43d1-870e-57afc8d75473"
+                workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListEventsResponse:
       description: The response for Events.list
       headers:

--- a/specs/2025-02-24.yaml
+++ b/specs/2025-02-24.yaml
@@ -59,13 +59,13 @@ paths:
         "200":
           $ref: "#/components/responses/SearchOrganizationsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/organizations/{id}:
     get:
       summary: Get organization
@@ -95,15 +95,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/programs:
     get:
       summary: List Programs
@@ -133,13 +133,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListProgramsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/programs/{id}:
     get:
       summary: Get Program
@@ -169,15 +169,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Program"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/connects:
     post:
       summary: Create Connect
@@ -227,15 +227,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/ConnectOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/connects/{id}:
     get:
       summary: Get Connect
@@ -265,15 +265,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Connect"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/grants:
     get:
       summary: List Grants
@@ -308,13 +308,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Grant
       description: |-
@@ -413,15 +413,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/recurring_grants:
     get:
       summary: List Recurring Grants
@@ -456,13 +456,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListRecurringGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Recurring Grant
       description: |-
@@ -551,15 +551,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/RecurringGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/unintegrated_grants:
     get:
       summary: List Unintegrated Grants
@@ -594,13 +594,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListUnintegratedGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/unintegrated_grants/{id}:
     get:
       summary: Get Unintegrated Grant
@@ -636,15 +636,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/dafs:
     get:
       summary: List Donor Advised Funds
@@ -689,11 +689,11 @@ paths:
         "200":
           $ref: "#/components/responses/ListDafsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/dafs/{id}:
     get:
       summary: Get Donor Advised Fund
@@ -729,13 +729,13 @@ paths:
                 Npt:
                   $ref: "#/components/examples/DafOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/events:
     get:
       summary: List Events
@@ -771,13 +771,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/events/{id}:
     get:
       summary: Get Event
@@ -803,15 +803,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Event"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/event_subscriptions:
     post:
       summary: Create an Event Subscription
@@ -835,15 +835,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     get:
       summary: List Event Subscriptions
       description: |-
@@ -871,13 +871,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventSubscriptionsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/event_subscriptions/{id}:
     get:
       summary: Get an Event Subscription
@@ -903,15 +903,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     patch:
       summary: Update an Event Subscription
       description: |-
@@ -938,15 +938,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/financial_accounts:
     get:
       summary: List financial accounts
@@ -3503,7 +3503,7 @@ components:
         title:
           type: string
           description: A short, human-readable summary of the problem type.
-          example: Bad Request
+          example: API Error
         status:
           type: integer
           description: The HTTP status code for this error.
@@ -3514,29 +3514,9 @@ components:
           example: The request is invalid or contains invalid parameters.
       example:
         type: about:blank
-        title: Bad Request
+        title: "API Error"
         status: 400
         detail: The request is invalid or contains invalid parameters.
-    ConnectError:
-      type: object
-      description: >-
-        Connect (gRPC) error format. The `code` field is a machine-readable
-        string code (not a number).
-      required:
-        - code
-        - message
-      properties:
-        code:
-          type: string
-          description: The machine-readable Connect error code.
-          example: invalid_argument
-        message:
-          type: string
-          description: A human-readable description of the error.
-          example: The request was invalid.
-      example:
-        code: invalid_argument
-        message: The request is invalid or contains invalid parameters.
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -4189,7 +4169,7 @@ components:
             BadRequest:
               value:
                 type: about:blank
-                title: "Bad Request"
+                title: "API Error"
                 status: 400
                 detail: "The request is invalid or contains invalid parameters."
     AuthenticationError:
@@ -4205,7 +4185,7 @@ components:
             Unauthorized:
               value:
                 type: about:blank
-                title: "Unauthorized"
+                title: "API Error"
                 status: 401
                 detail: "Authentication credentials were missing or invalid."
     ForbiddenError:
@@ -4221,7 +4201,7 @@ components:
             Forbidden:
               value:
                 type: about:blank
-                title: "Forbidden"
+                title: "API Error"
                 status: 403
                 detail: "You do not have permission to access this resource."
     NotFoundError:
@@ -4237,7 +4217,7 @@ components:
             NotFound:
               value:
                 type: about:blank
-                title: "Not Found"
+                title: "API Error"
                 status: 404
                 detail: "The requested resource was not found."
     ConflictError:
@@ -4253,7 +4233,7 @@ components:
             Conflict:
               value:
                 type: about:blank
-                title: "Conflict"
+                title: "API Error"
                 status: 409
                 detail: "The request conflicts with the current state of the resource."
     GoneError:
@@ -4269,7 +4249,7 @@ components:
             Gone:
               value:
                 type: about:blank
-                title: "Gone"
+                title: "API Error"
                 status: 410
                 detail: "The resource is no longer available."
     PreconditionFailedError:
@@ -4285,7 +4265,7 @@ components:
             PreconditionFailed:
               value:
                 type: about:blank
-                title: "Precondition Failed"
+                title: "API Error"
                 status: 412
                 detail: "A precondition for the request was not met."
     InternalServerError:
@@ -4301,121 +4281,9 @@ components:
             InternalServerError:
               value:
                 type: about:blank
-                title: "Internal server error"
+                title: "API Error"
                 status: 500
                 detail: "The server encountered an error processing your request."
-    ConnectBadRequestError:
-      description: The request is invalid or contains invalid parameters
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            BadRequest:
-              value:
-                code: invalid_argument
-                message: "The request is invalid or contains invalid parameters."
-    ConnectAuthenticationError:
-      description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Unauthorized:
-              value:
-                code: unauthenticated
-                message: "Authentication credentials were missing or invalid."
-    ConnectForbiddenError:
-      description: Access denied
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Forbidden:
-              value:
-                code: permission_denied
-                message: "You do not have permission to access this resource."
-    ConnectNotFoundError:
-      description: Resource Not Found
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            NotFound:
-              value:
-                code: not_found
-                message: "The requested resource was not found."
-    ConnectConflictError:
-      description: Resource Conflicts
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Conflict:
-              value:
-                code: aborted
-                message: "The request conflicts with the current state of the resource."
-    ConnectGoneError:
-      description: Resource Gone or Expired
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Gone:
-              value:
-                code: not_found
-                message: "The resource is no longer available."
-    ConnectPreconditionFailedError:
-      description: Precondition Failed
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            PreconditionFailed:
-              value:
-                code: failed_precondition
-                message: "A precondition for the request was not met."
-    ConnectInternalServerError:
-      description: Internal Server Error
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            InternalServerError:
-              value:
-                code: internal
-                message: "The server encountered an error processing your request."
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2025-02-24.yaml
+++ b/specs/2025-02-24.yaml
@@ -3487,9 +3487,7 @@ components:
       type: object
       description: >-
         RFC 7807 problem-details error (media type application/problem+json).
-        The `status` field is an integer HTTP status code; it is unrelated to a
-        resource's `status` string (e.g. a grant's "Initiated"). Parse a body as
-        a resource only on 2xx.
+        The `status` field is an integer HTTP status code.
       required:
         - type
         - title

--- a/specs/2025-02-24.yaml
+++ b/specs/2025-02-24.yaml
@@ -3978,34 +3978,19 @@ components:
                 type: string
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only substituting the pageToken with this value). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
-                    orgName: "National Philanthropic Trust"
-                    address: "123 Main St."
-                    address2: "Apt 100"
-                    city: "New York"
-                    state: "NY"
-                    zip: "12345"
-                    supported: true
-                    minimumGrantAmount: 5000
-                    institutionDown: false
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
-                    orgName: "National Philanthropic Trust"
-                    address: "123 Main St."
-                    address2: "Apt 100"
-                    city: "New York"
-                    state: "NY"
-                    zip: "12345"
-                    supported: true
-                    minimumGrantAmount: 5000
-                    institutionDown: false
+          example:
+            results:
+              - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
+                orgName: "National Philanthropic Trust"
+                address: "123 Main St."
+                address2: "Apt 100"
+                city: "New York"
+                state: "NY"
+                zip: "12345"
+                supported: true
+                minimumGrantAmount: 5000
+                institutionDown: false
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListGrantsResponse:
       description: The response for Grants.list
       headers:
@@ -4025,29 +4010,16 @@ components:
                 nullable: true
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the pageToken). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                    status: "Initiated"
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 20000
-                    status: "Received"
-                nextPageToken: null
+          example:
+            results:
+              - id: "1e60800e-849b-43d1-870e-57afc8d75473"
+                workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+                status: "Initiated"
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListRecurringGrantsResponse:
       description: The response for RecurringGrants.list
       headers:
@@ -4066,28 +4038,16 @@ components:
                 type: string
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the pageToken). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "29650c10-1eb3-4f97-a63e-f2e41c145b53"
-                    workflowSessionId: "b76fa69f-c554-43b2-af9a-1d4bb9a02016"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                    frequency: MONTHLY
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "579e2864-d65a-4a21-a056-1c91d0a95b5c"
-                    workflowSessionId: "ee27b65b-22f5-42fa-b966-0f83cac8fd2c"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 16:00:00.000"
-                    updatedAt: "2021-08-11 15:25:00.000"
-                    amount: 20000
-                    frequency: MONTHLY
+          example:
+            results:
+              - id: "29650c10-1eb3-4f97-a63e-f2e41c145b53"
+                workflowSessionId: "b76fa69f-c554-43b2-af9a-1d4bb9a02016"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+                frequency: MONTHLY
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListUnintegratedGrantsResponse:
       description: The response for UnintegratedGrants.list
       headers:
@@ -4109,26 +4069,15 @@ components:
                    to the same endpoint with the same parameters (only changing the pageToken). If
                    specified, then more results exist on the server that were not returned, otherwise
                    no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 20000
+          example:
+            results:
+              - id: "1e60800e-849b-43d1-870e-57afc8d75473"
+                workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListEventsResponse:
       description: The response for Events.list
       headers:

--- a/specs/2025-02-24.yaml
+++ b/specs/2025-02-24.yaml
@@ -3512,6 +3512,11 @@ components:
           type: string
           description: A human-readable explanation specific to this occurrence.
           example: The request is invalid or contains invalid parameters.
+      example:
+        type: about:blank
+        title: Bad Request
+        status: 400
+        detail: The request is invalid or contains invalid parameters.
     ConnectError:
       type: object
       description: >-
@@ -3531,9 +3536,28 @@ components:
           example: The request was invalid.
         details:
           type: array
-          description: Optional structured error details.
+          description: Optional structured error details (e.g. google.rpc.ErrorInfo entries carrying the request id).
           items:
             type: object
+            properties:
+              type:
+                type: string
+                description: The fully-qualified type of the detail entry.
+                example: google.rpc.ErrorInfo
+              value:
+                type: string
+                description: Base64-encoded protobuf payload for the detail entry.
+              debug:
+                type: object
+                description: Human-readable debug metadata (omitted in production).
+      example:
+        code: invalid_argument
+        message: The request is invalid or contains invalid parameters.
+        details:
+          - type: google.rpc.ErrorInfo
+            debug:
+              metadata:
+                X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   headers:
     X-Request-Id:
       description: The unique identifier for the request

--- a/specs/2025-02-24.yaml
+++ b/specs/2025-02-24.yaml
@@ -59,13 +59,13 @@ paths:
         "200":
           $ref: "#/components/responses/SearchOrganizationsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/organizations/{id}:
     get:
       summary: Get organization
@@ -95,15 +95,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/programs:
     get:
       summary: List Programs
@@ -133,13 +133,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListProgramsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/programs/{id}:
     get:
       summary: Get Program
@@ -169,15 +169,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Program"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/connects:
     post:
       summary: Create Connect
@@ -227,15 +227,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/ConnectOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/connects/{id}:
     get:
       summary: Get Connect
@@ -265,15 +265,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Connect"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/grants:
     get:
       summary: List Grants
@@ -308,13 +308,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     post:
       summary: Create Grant
       description: |-
@@ -413,15 +413,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/recurring_grants:
     get:
       summary: List Recurring Grants
@@ -456,13 +456,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListRecurringGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     post:
       summary: Create Recurring Grant
       description: |-
@@ -551,15 +551,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/RecurringGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/unintegrated_grants:
     get:
       summary: List Unintegrated Grants
@@ -594,13 +594,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListUnintegratedGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/unintegrated_grants/{id}:
     get:
       summary: Get Unintegrated Grant
@@ -636,15 +636,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/dafs:
     get:
       summary: List Donor Advised Funds
@@ -689,11 +689,11 @@ paths:
         "200":
           $ref: "#/components/responses/ListDafsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/dafs/{id}:
     get:
       summary: Get Donor Advised Fund
@@ -729,13 +729,13 @@ paths:
                 Npt:
                   $ref: "#/components/examples/DafOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/events:
     get:
       summary: List Events
@@ -771,13 +771,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/events/{id}:
     get:
       summary: Get Event
@@ -803,15 +803,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Event"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/event_subscriptions:
     post:
       summary: Create an Event Subscription
@@ -835,15 +835,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     get:
       summary: List Event Subscriptions
       description: |-
@@ -871,13 +871,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventSubscriptionsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/event_subscriptions/{id}:
     get:
       summary: Get an Event Subscription
@@ -903,15 +903,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     patch:
       summary: Update an Event Subscription
       description: |-
@@ -938,15 +938,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/financial_accounts:
     get:
       summary: List financial accounts
@@ -3483,30 +3483,57 @@ components:
           example: "eyJpZCI6IjEyMzQ1Njc4OTAiLCJ0aW1lc3RhbXAiOiIyMDIwLTA3LTEwIDE1OjAwOjAwLjAwMCJ9"
         total:
           type: integer
-    Error:
+    ProblemDetails:
       type: object
+      description: >-
+        RFC 7807 problem-details error (media type application/problem+json),
+        returned by resource and DAFpay endpoints. The `status` field is an
+        integer HTTP status code; it is unrelated to a resource's `status`
+        string (e.g. a grant's "Initiated"). Parse a body as a resource only on 2xx.
       required:
-        - timestamp
+        - type
+        - title
+        - status
+        - detail
+      properties:
+        type:
+          type: string
+          description: A URI reference identifying the problem type.
+          example: about:blank
+        title:
+          type: string
+          description: A short, human-readable summary of the problem type.
+          example: Bad Request
+        status:
+          type: integer
+          description: The HTTP status code for this error.
+          example: 400
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence.
+          example: The request is invalid or contains invalid parameters.
+    ConnectError:
+      type: object
+      description: >-
+        Connect (gRPC) error returned by the grantmaker read and query endpoints.
+        The `code` field is a machine-readable string code (not a number).
+      required:
         - code
-        - error
         - message
       properties:
-        timestamp:
-          type: string
-          description: time when the error was reported. Expressed in RFC 3339 format.
-          example: "2020-01-31T23:00:00Z"
         code:
-          type: number
-          description: HTTP status code of the error
-          example: 400
-        error:
           type: string
-          description: A short name of the error; usually the HTTP status.
-          example: Bad Request
+          description: The machine-readable Connect error code.
+          example: invalid_argument
         message:
           type: string
-          description: The description of the error
-          example: Expected an API key to be provided in the header `x-chariot-api-key`
+          description: A human-readable description of the error.
+          example: The request was invalid.
+        details:
+          type: array
+          description: Optional structured error details.
+          items:
+            type: object
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -4203,15 +4230,125 @@ components:
         X-Request-Id:
           $ref: "#/components/headers/X-Request-Id"
       content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Bad Request"
+            status: 400
+            detail: "The request is invalid or contains invalid parameters."
+    AuthenticationError:
+      description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Unauthorized"
+            status: 401
+            detail: "Authentication credentials were missing or invalid."
+    ForbiddenError:
+      description: Access denied
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Forbidden"
+            status: 403
+            detail: "You do not have permission to access this resource."
+    NotFoundError:
+      description: Resource Not Found
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Not Found"
+            status: 404
+            detail: "The requested resource was not found."
+    ConflictError:
+      description: Resource Conflicts
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Conflict"
+            status: 409
+            detail: "The request conflicts with the current state of the resource."
+    GoneError:
+      description: Resource Gone or Expired
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Gone"
+            status: 410
+            detail: "The resource is no longer available."
+    PreconditionFailedError:
+      description: Precondition Failed
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Precondition Failed"
+            status: 412
+            detail: "A precondition for the request was not met."
+    InternalServerError:
+      description: Internal Server Error
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Internal server error"
+            status: 500
+            detail: "The server encountered an error processing your request."
+    ConnectBadRequestError:
+      description: The request is invalid or contains invalid parameters
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 400
-            error: "Bad Request"
-            message: "Expected an API key to be provided in the header `x-chariot-api-key`"
-    AuthenticationError:
+            code: invalid_argument
+            message: "The request is invalid or contains invalid parameters."
+    ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
         X-Request-Id:
@@ -4219,13 +4356,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 401
-            error: "Unauthorized"
-            message: "Unauthorized"
-    ForbiddenError:
+            code: unauthenticated
+            message: "Authentication credentials were missing or invalid."
+    ConnectForbiddenError:
       description: Access denied
       headers:
         X-Request-Id:
@@ -4233,13 +4368,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 403
-            error: "Forbidden"
-            message: "User is not allowed to access this resource"
-    NotFoundError:
+            code: permission_denied
+            message: "You do not have permission to access this resource."
+    ConnectNotFoundError:
       description: Resource Not Found
       headers:
         X-Request-Id:
@@ -4247,13 +4380,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 404
-            error: "Not Found"
-            message: "Resource is not found"
-    ConflictError:
+            code: not_found
+            message: "The requested resource was not found."
+    ConnectConflictError:
       description: Resource Conflicts
       headers:
         X-Request-Id:
@@ -4261,13 +4392,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 409
-            error: "Conflict"
-            message: "Request conflicts with an already existing resource"
-    GoneError:
+            code: aborted
+            message: "The request conflicts with the current state of the resource."
+    ConnectGoneError:
       description: Resource Gone or Expired
       headers:
         X-Request-Id:
@@ -4275,13 +4404,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 410
-            error: "Gone"
-            message: "The resource has expired"
-    PreconditionFailedError:
+            code: not_found
+            message: "The resource is no longer available."
+    ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
         X-Request-Id:
@@ -4289,13 +4416,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 412
-            error: "Precondition Failed"
-            message: "The requested action has a failed precondition"
-    InternalServerError:
+            code: failed_precondition
+            message: "A precondition for the request was not met."
+    ConnectInternalServerError:
       description: Internal Server Error
       headers:
         X-Request-Id:
@@ -4303,12 +4428,10 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 500
-            error: "Internal server error"
-            message: "The server encountered an error processing your request"
+            code: internal
+            message: "The server encountered an error processing your request."
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2025-02-24.yaml
+++ b/specs/2025-02-24.yaml
@@ -4257,11 +4257,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Bad Request"
-            status: 400
-            detail: "The request is invalid or contains invalid parameters."
+          examples:
+            BadRequest:
+              value:
+                type: about:blank
+                title: "Bad Request"
+                status: 400
+                detail: "The request is invalid or contains invalid parameters."
     AuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -4271,11 +4273,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Unauthorized"
-            status: 401
-            detail: "Authentication credentials were missing or invalid."
+          examples:
+            Unauthorized:
+              value:
+                type: about:blank
+                title: "Unauthorized"
+                status: 401
+                detail: "Authentication credentials were missing or invalid."
     ForbiddenError:
       description: Access denied
       headers:
@@ -4285,11 +4289,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Forbidden"
-            status: 403
-            detail: "You do not have permission to access this resource."
+          examples:
+            Forbidden:
+              value:
+                type: about:blank
+                title: "Forbidden"
+                status: 403
+                detail: "You do not have permission to access this resource."
     NotFoundError:
       description: Resource Not Found
       headers:
@@ -4299,11 +4305,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Not Found"
-            status: 404
-            detail: "The requested resource was not found."
+          examples:
+            NotFound:
+              value:
+                type: about:blank
+                title: "Not Found"
+                status: 404
+                detail: "The requested resource was not found."
     ConflictError:
       description: Resource Conflicts
       headers:
@@ -4313,11 +4321,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Conflict"
-            status: 409
-            detail: "The request conflicts with the current state of the resource."
+          examples:
+            Conflict:
+              value:
+                type: about:blank
+                title: "Conflict"
+                status: 409
+                detail: "The request conflicts with the current state of the resource."
     GoneError:
       description: Resource Gone or Expired
       headers:
@@ -4327,11 +4337,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Gone"
-            status: 410
-            detail: "The resource is no longer available."
+          examples:
+            Gone:
+              value:
+                type: about:blank
+                title: "Gone"
+                status: 410
+                detail: "The resource is no longer available."
     PreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -4341,11 +4353,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Precondition Failed"
-            status: 412
-            detail: "A precondition for the request was not met."
+          examples:
+            PreconditionFailed:
+              value:
+                type: about:blank
+                title: "Precondition Failed"
+                status: 412
+                detail: "A precondition for the request was not met."
     InternalServerError:
       description: Internal Server Error
       headers:
@@ -4355,11 +4369,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Internal server error"
-            status: 500
-            detail: "The server encountered an error processing your request."
+          examples:
+            InternalServerError:
+              value:
+                type: about:blank
+                title: "Internal server error"
+                status: 500
+                detail: "The server encountered an error processing your request."
     ConnectBadRequestError:
       description: The request is invalid or contains invalid parameters
       headers:
@@ -4369,9 +4385,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: invalid_argument
-            message: "The request is invalid or contains invalid parameters."
+          examples:
+            BadRequest:
+              value:
+                code: invalid_argument
+                message: "The request is invalid or contains invalid parameters."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -4381,9 +4404,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: unauthenticated
-            message: "Authentication credentials were missing or invalid."
+          examples:
+            Unauthorized:
+              value:
+                code: unauthenticated
+                message: "Authentication credentials were missing or invalid."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectForbiddenError:
       description: Access denied
       headers:
@@ -4393,9 +4423,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: permission_denied
-            message: "You do not have permission to access this resource."
+          examples:
+            Forbidden:
+              value:
+                code: permission_denied
+                message: "You do not have permission to access this resource."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectNotFoundError:
       description: Resource Not Found
       headers:
@@ -4405,9 +4442,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: not_found
-            message: "The requested resource was not found."
+          examples:
+            NotFound:
+              value:
+                code: not_found
+                message: "The requested resource was not found."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectConflictError:
       description: Resource Conflicts
       headers:
@@ -4417,9 +4461,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: aborted
-            message: "The request conflicts with the current state of the resource."
+          examples:
+            Conflict:
+              value:
+                code: aborted
+                message: "The request conflicts with the current state of the resource."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectGoneError:
       description: Resource Gone or Expired
       headers:
@@ -4429,9 +4480,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: not_found
-            message: "The resource is no longer available."
+          examples:
+            Gone:
+              value:
+                code: not_found
+                message: "The resource is no longer available."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -4441,9 +4499,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: failed_precondition
-            message: "A precondition for the request was not met."
+          examples:
+            PreconditionFailed:
+              value:
+                code: failed_precondition
+                message: "A precondition for the request was not met."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectInternalServerError:
       description: Internal Server Error
       headers:
@@ -4453,9 +4518,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: internal
-            message: "The server encountered an error processing your request."
+          examples:
+            InternalServerError:
+              value:
+                code: internal
+                message: "The server encountered an error processing your request."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2025-02-24.yaml
+++ b/specs/2025-02-24.yaml
@@ -3486,10 +3486,10 @@ components:
     ProblemDetails:
       type: object
       description: >-
-        RFC 7807 problem-details error (media type application/problem+json),
-        returned by resource and DAFpay endpoints. The `status` field is an
-        integer HTTP status code; it is unrelated to a resource's `status`
-        string (e.g. a grant's "Initiated"). Parse a body as a resource only on 2xx.
+        RFC 7807 problem-details error (media type application/problem+json).
+        The `status` field is an integer HTTP status code; it is unrelated to a
+        resource's `status` string (e.g. a grant's "Initiated"). Parse a body as
+        a resource only on 2xx.
       required:
         - type
         - title
@@ -3520,8 +3520,8 @@ components:
     ConnectError:
       type: object
       description: >-
-        Connect (gRPC) error returned by the grantmaker read and query endpoints.
-        The `code` field is a machine-readable string code (not a number).
+        Connect (gRPC) error format. The `code` field is a machine-readable
+        string code (not a number).
       required:
         - code
         - message
@@ -3534,30 +3534,9 @@ components:
           type: string
           description: A human-readable description of the error.
           example: The request was invalid.
-        details:
-          type: array
-          description: Optional structured error details (e.g. google.rpc.ErrorInfo entries carrying the request id).
-          items:
-            type: object
-            properties:
-              type:
-                type: string
-                description: The fully-qualified type of the detail entry.
-                example: google.rpc.ErrorInfo
-              value:
-                type: string
-                description: Base64-encoded protobuf payload for the detail entry.
-              debug:
-                type: object
-                description: Human-readable debug metadata (omitted in production).
       example:
         code: invalid_argument
         message: The request is invalid or contains invalid parameters.
-        details:
-          - type: google.rpc.ErrorInfo
-            debug:
-              metadata:
-                X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -4339,11 +4318,6 @@ components:
               value:
                 code: invalid_argument
                 message: "The request is invalid or contains invalid parameters."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -4358,11 +4332,6 @@ components:
               value:
                 code: unauthenticated
                 message: "Authentication credentials were missing or invalid."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectForbiddenError:
       description: Access denied
       headers:
@@ -4377,11 +4346,6 @@ components:
               value:
                 code: permission_denied
                 message: "You do not have permission to access this resource."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectNotFoundError:
       description: Resource Not Found
       headers:
@@ -4396,11 +4360,6 @@ components:
               value:
                 code: not_found
                 message: "The requested resource was not found."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectConflictError:
       description: Resource Conflicts
       headers:
@@ -4415,11 +4374,6 @@ components:
               value:
                 code: aborted
                 message: "The request conflicts with the current state of the resource."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectGoneError:
       description: Resource Gone or Expired
       headers:
@@ -4434,11 +4388,6 @@ components:
               value:
                 code: not_found
                 message: "The resource is no longer available."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -4453,11 +4402,6 @@ components:
               value:
                 code: failed_precondition
                 message: "A precondition for the request was not met."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectInternalServerError:
       description: Internal Server Error
       headers:
@@ -4472,11 +4416,6 @@ components:
               value:
                 code: internal
                 message: "The server encountered an error processing your request."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -6515,11 +6515,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Bad Request"
-            status: 400
-            detail: "The request is invalid or contains invalid parameters."
+          examples:
+            BadRequest:
+              value:
+                type: about:blank
+                title: "Bad Request"
+                status: 400
+                detail: "The request is invalid or contains invalid parameters."
     AuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -6529,11 +6531,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Unauthorized"
-            status: 401
-            detail: "Authentication credentials were missing or invalid."
+          examples:
+            Unauthorized:
+              value:
+                type: about:blank
+                title: "Unauthorized"
+                status: 401
+                detail: "Authentication credentials were missing or invalid."
     ForbiddenError:
       description: Access denied
       headers:
@@ -6543,11 +6547,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Forbidden"
-            status: 403
-            detail: "You do not have permission to access this resource."
+          examples:
+            Forbidden:
+              value:
+                type: about:blank
+                title: "Forbidden"
+                status: 403
+                detail: "You do not have permission to access this resource."
     NotFoundError:
       description: Resource Not Found
       headers:
@@ -6557,11 +6563,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Not Found"
-            status: 404
-            detail: "The requested resource was not found."
+          examples:
+            NotFound:
+              value:
+                type: about:blank
+                title: "Not Found"
+                status: 404
+                detail: "The requested resource was not found."
     ConflictError:
       description: Resource Conflicts
       headers:
@@ -6571,11 +6579,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Conflict"
-            status: 409
-            detail: "The request conflicts with the current state of the resource."
+          examples:
+            Conflict:
+              value:
+                type: about:blank
+                title: "Conflict"
+                status: 409
+                detail: "The request conflicts with the current state of the resource."
     GoneError:
       description: Resource Gone or Expired
       headers:
@@ -6585,11 +6595,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Gone"
-            status: 410
-            detail: "The resource is no longer available."
+          examples:
+            Gone:
+              value:
+                type: about:blank
+                title: "Gone"
+                status: 410
+                detail: "The resource is no longer available."
     PreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -6599,11 +6611,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Precondition Failed"
-            status: 412
-            detail: "A precondition for the request was not met."
+          examples:
+            PreconditionFailed:
+              value:
+                type: about:blank
+                title: "Precondition Failed"
+                status: 412
+                detail: "A precondition for the request was not met."
     InternalServerError:
       description: Internal Server Error
       headers:
@@ -6613,11 +6627,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Internal server error"
-            status: 500
-            detail: "The server encountered an error processing your request."
+          examples:
+            InternalServerError:
+              value:
+                type: about:blank
+                title: "Internal server error"
+                status: 500
+                detail: "The server encountered an error processing your request."
     ConnectBadRequestError:
       description: The request is invalid or contains invalid parameters
       headers:
@@ -6627,9 +6643,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: invalid_argument
-            message: "The request is invalid or contains invalid parameters."
+          examples:
+            BadRequest:
+              value:
+                code: invalid_argument
+                message: "The request is invalid or contains invalid parameters."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -6639,9 +6662,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: unauthenticated
-            message: "Authentication credentials were missing or invalid."
+          examples:
+            Unauthorized:
+              value:
+                code: unauthenticated
+                message: "Authentication credentials were missing or invalid."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectForbiddenError:
       description: Access denied
       headers:
@@ -6651,9 +6681,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: permission_denied
-            message: "You do not have permission to access this resource."
+          examples:
+            Forbidden:
+              value:
+                code: permission_denied
+                message: "You do not have permission to access this resource."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectNotFoundError:
       description: Resource Not Found
       headers:
@@ -6663,9 +6700,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: not_found
-            message: "The requested resource was not found."
+          examples:
+            NotFound:
+              value:
+                code: not_found
+                message: "The requested resource was not found."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectConflictError:
       description: Resource Conflicts
       headers:
@@ -6675,9 +6719,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: aborted
-            message: "The request conflicts with the current state of the resource."
+          examples:
+            Conflict:
+              value:
+                code: aborted
+                message: "The request conflicts with the current state of the resource."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectGoneError:
       description: Resource Gone or Expired
       headers:
@@ -6687,9 +6738,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: not_found
-            message: "The resource is no longer available."
+          examples:
+            Gone:
+              value:
+                code: not_found
+                message: "The resource is no longer available."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -6699,9 +6757,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: failed_precondition
-            message: "A precondition for the request was not met."
+          examples:
+            PreconditionFailed:
+              value:
+                code: failed_precondition
+                message: "A precondition for the request was not met."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectInternalServerError:
       description: Internal Server Error
       headers:
@@ -6711,9 +6776,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: internal
-            message: "The server encountered an error processing your request."
+          examples:
+            InternalServerError:
+              value:
+                code: internal
+                message: "The server encountered an error processing your request."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -5382,9 +5382,7 @@ components:
       type: object
       description: >-
         RFC 7807 problem-details error (media type application/problem+json).
-        The `status` field is an integer HTTP status code; it is unrelated to a
-        resource's `status` string (e.g. a grant's "Initiated"). Parse a body as
-        a resource only on 2xx.
+        The `status` field is an integer HTTP status code.
       required:
         - type
         - title

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -6055,34 +6055,19 @@ components:
                 type: string
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only substituting the pageToken with this value). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
-                    orgName: "National Philanthropic Trust"
-                    address: "123 Main St."
-                    address2: "Apt 100"
-                    city: "New York"
-                    state: "NY"
-                    zip: "12345"
-                    supported: true
-                    minimumGrantAmount: 5000
-                    institutionDown: false
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
-                    orgName: "National Philanthropic Trust"
-                    address: "123 Main St."
-                    address2: "Apt 100"
-                    city: "New York"
-                    state: "NY"
-                    zip: "12345"
-                    supported: true
-                    minimumGrantAmount: 5000
-                    institutionDown: false
+          example:
+            results:
+              - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
+                orgName: "National Philanthropic Trust"
+                address: "123 Main St."
+                address2: "Apt 100"
+                city: "New York"
+                state: "NY"
+                zip: "12345"
+                supported: true
+                minimumGrantAmount: 5000
+                institutionDown: false
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListGrantsResponse:
       description: The response for Grants.list
       headers:
@@ -6102,29 +6087,16 @@ components:
                 nullable: true
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the pageToken). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                    status: "Initiated"
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 20000
-                    status: "Received"
-                nextPageToken: null
+          example:
+            results:
+              - id: "1e60800e-849b-43d1-870e-57afc8d75473"
+                workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+                status: "Initiated"
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListRecurringGrantsResponse:
       description: The response for RecurringGrants.list
       headers:
@@ -6143,28 +6115,16 @@ components:
                 type: string
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the pageToken). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "29650c10-1eb3-4f97-a63e-f2e41c145b53"
-                    workflowSessionId: "b76fa69f-c554-43b2-af9a-1d4bb9a02016"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                    frequency: MONTHLY
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "579e2864-d65a-4a21-a056-1c91d0a95b5c"
-                    workflowSessionId: "ee27b65b-22f5-42fa-b966-0f83cac8fd2c"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 16:00:00.000"
-                    updatedAt: "2021-08-11 15:25:00.000"
-                    amount: 20000
-                    frequency: MONTHLY
+          example:
+            results:
+              - id: "29650c10-1eb3-4f97-a63e-f2e41c145b53"
+                workflowSessionId: "b76fa69f-c554-43b2-af9a-1d4bb9a02016"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+                frequency: MONTHLY
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListUnintegratedGrantsResponse:
       description: The response for UnintegratedGrants.list
       headers:
@@ -6186,26 +6146,15 @@ components:
                    to the same endpoint with the same parameters (only changing the pageToken). If
                    specified, then more results exist on the server that were not returned, otherwise
                    no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 20000
+          example:
+            results:
+              - id: "1e60800e-849b-43d1-870e-57afc8d75473"
+                workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListEventsResponse:
       description: The response for Events.list
       headers:

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -5381,10 +5381,10 @@ components:
     ProblemDetails:
       type: object
       description: >-
-        RFC 7807 problem-details error (media type application/problem+json),
-        returned by resource and DAFpay endpoints. The `status` field is an
-        integer HTTP status code; it is unrelated to a resource's `status`
-        string (e.g. a grant's "Initiated"). Parse a body as a resource only on 2xx.
+        RFC 7807 problem-details error (media type application/problem+json).
+        The `status` field is an integer HTTP status code; it is unrelated to a
+        resource's `status` string (e.g. a grant's "Initiated"). Parse a body as
+        a resource only on 2xx.
       required:
         - type
         - title
@@ -5415,8 +5415,8 @@ components:
     ConnectError:
       type: object
       description: >-
-        Connect (gRPC) error returned by the grantmaker read and query endpoints.
-        The `code` field is a machine-readable string code (not a number).
+        Connect (gRPC) error format. The `code` field is a machine-readable
+        string code (not a number).
       required:
         - code
         - message
@@ -5429,30 +5429,9 @@ components:
           type: string
           description: A human-readable description of the error.
           example: The request was invalid.
-        details:
-          type: array
-          description: Optional structured error details (e.g. google.rpc.ErrorInfo entries carrying the request id).
-          items:
-            type: object
-            properties:
-              type:
-                type: string
-                description: The fully-qualified type of the detail entry.
-                example: google.rpc.ErrorInfo
-              value:
-                type: string
-                description: Base64-encoded protobuf payload for the detail entry.
-              debug:
-                type: object
-                description: Human-readable debug metadata (omitted in production).
       example:
         code: invalid_argument
         message: The request is invalid or contains invalid parameters.
-        details:
-          - type: google.rpc.ErrorInfo
-            debug:
-              metadata:
-                X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -6597,11 +6576,6 @@ components:
               value:
                 code: invalid_argument
                 message: "The request is invalid or contains invalid parameters."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -6616,11 +6590,6 @@ components:
               value:
                 code: unauthenticated
                 message: "Authentication credentials were missing or invalid."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectForbiddenError:
       description: Access denied
       headers:
@@ -6635,11 +6604,6 @@ components:
               value:
                 code: permission_denied
                 message: "You do not have permission to access this resource."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectNotFoundError:
       description: Resource Not Found
       headers:
@@ -6654,11 +6618,6 @@ components:
               value:
                 code: not_found
                 message: "The requested resource was not found."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectConflictError:
       description: Resource Conflicts
       headers:
@@ -6673,11 +6632,6 @@ components:
               value:
                 code: aborted
                 message: "The request conflicts with the current state of the resource."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectGoneError:
       description: Resource Gone or Expired
       headers:
@@ -6692,11 +6646,6 @@ components:
               value:
                 code: not_found
                 message: "The resource is no longer available."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -6711,11 +6660,6 @@ components:
               value:
                 code: failed_precondition
                 message: "A precondition for the request was not met."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectInternalServerError:
       description: Internal Server Error
       headers:
@@ -6730,11 +6674,6 @@ components:
               value:
                 code: internal
                 message: "The server encountered an error processing your request."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -59,13 +59,13 @@ paths:
         "200":
           $ref: "#/components/responses/SearchOrganizationsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/organizations/{id}:
     get:
       summary: Get organization
@@ -95,15 +95,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/programs:
     get:
       summary: List Programs
@@ -133,13 +133,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListProgramsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/programs/{id}:
     get:
       summary: Get Program
@@ -169,15 +169,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Program"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/connects:
     post:
       summary: Create Connect
@@ -227,15 +227,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/ConnectOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/connects/{id}:
     get:
       summary: Get Connect
@@ -265,15 +265,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Connect"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/grants:
     get:
       summary: List Grants
@@ -308,13 +308,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Grant
       description: |-
@@ -413,15 +413,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/recurring_grants:
     get:
       summary: List Recurring Grants
@@ -456,13 +456,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListRecurringGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Recurring Grant
       description: |-
@@ -551,15 +551,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/RecurringGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/unintegrated_grants:
     get:
       summary: List Unintegrated Grants
@@ -594,13 +594,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListUnintegratedGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/unintegrated_grants/{id}:
     get:
       summary: Get Unintegrated Grant
@@ -636,15 +636,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/dafs:
     get:
       summary: List Donor Advised Funds
@@ -689,11 +689,11 @@ paths:
         "200":
           $ref: "#/components/responses/ListDafsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/dafs/{id}:
     get:
       summary: Get Donor Advised Fund
@@ -729,13 +729,13 @@ paths:
                 Npt:
                   $ref: "#/components/examples/DafOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/events:
     get:
       summary: List Events
@@ -771,13 +771,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/events/{id}:
     get:
       summary: Get Event
@@ -803,15 +803,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Event"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/event_subscriptions:
     post:
       summary: Create an Event Subscription
@@ -835,15 +835,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     get:
       summary: List Event Subscriptions
       description: |-
@@ -871,13 +871,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventSubscriptionsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/event_subscriptions/{id}:
     get:
       summary: Get an Event Subscription
@@ -903,15 +903,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     patch:
       summary: Update an Event Subscription
       description: |-
@@ -938,15 +938,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/financial_accounts:
     get:
       summary: List financial accounts
@@ -1062,15 +1062,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerificationRequest"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "409":
-          $ref: "#/components/responses/ConnectConflictError"
+          $ref: "#/components/responses/ConflictError"
         "412":
-          $ref: "#/components/responses/ConnectPreconditionFailedError"
+          $ref: "#/components/responses/PreconditionFailedError"
     get:
       summary: List verification requests
       description: |
@@ -1105,13 +1105,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListVerificationRequestsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/verification_requests/{id}:
     get:
       summary: Get a verification request
@@ -1140,13 +1140,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerificationRequest"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/disbursements:
     post:
       summary: Create a disbursement
@@ -1836,13 +1836,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListPaymentSourcesResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/payment_sources/{id}:
     get:
       summary: Get a Payment Source
@@ -1878,15 +1878,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/PaymentSource"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/donations:
     get:
       summary: List Donations
@@ -1943,13 +1943,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDonationsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/donations/{id}:
     get:
       summary: Get a Donation
@@ -1976,15 +1976,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Donation"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/deposits:
     get:
       summary: List Deposits
@@ -2034,13 +2034,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDepositsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/deposits/{id}:
     get:
       summary: Get a Deposit
@@ -2067,15 +2067,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Deposit"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/properties:
     get:
       summary: List Properties
@@ -2110,13 +2110,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListPropertiesResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/properties/{id}:
     get:
       summary: Get a Property
@@ -2143,15 +2143,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Property"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/properties/{id}/options:
     get:
       summary: List Property Options
@@ -2187,15 +2187,15 @@ paths:
         "200":
           $ref: "#/components/responses/ListPropertyOptionsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/properties/{id}/assign:
     post:
       summary: Assign a Property
@@ -2222,15 +2222,15 @@ paths:
         "200":
           $ref: "#/components/responses/AssignPropertyResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/mailbox/upload_url:
     post:
       summary: Get a Batch Upload URL
@@ -2321,13 +2321,13 @@ paths:
         "200":
           description: Indicates the PO box has been successfully provisioned.
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/nonprofit_addresses:
     post:
       summary: Create Nonprofit Addresses
@@ -2345,15 +2345,15 @@ paths:
         "200":
           description: All addresses were accepted.
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/nonprofit_contacts:
     post:
       summary: Create Nonprofit Contacts
@@ -2371,15 +2371,15 @@ paths:
         "200":
           description: All suggestions were accepted.
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
 components:
   securitySchemes:
     bearerAuth:
@@ -5398,7 +5398,7 @@ components:
         title:
           type: string
           description: A short, human-readable summary of the problem type.
-          example: Bad Request
+          example: API Error
         status:
           type: integer
           description: The HTTP status code for this error.
@@ -5409,29 +5409,9 @@ components:
           example: The request is invalid or contains invalid parameters.
       example:
         type: about:blank
-        title: Bad Request
+        title: "API Error"
         status: 400
         detail: The request is invalid or contains invalid parameters.
-    ConnectError:
-      type: object
-      description: >-
-        Connect (gRPC) error format. The `code` field is a machine-readable
-        string code (not a number).
-      required:
-        - code
-        - message
-      properties:
-        code:
-          type: string
-          description: The machine-readable Connect error code.
-          example: invalid_argument
-        message:
-          type: string
-          description: A human-readable description of the error.
-          example: The request was invalid.
-      example:
-        code: invalid_argument
-        message: The request is invalid or contains invalid parameters.
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -6447,7 +6427,7 @@ components:
             BadRequest:
               value:
                 type: about:blank
-                title: "Bad Request"
+                title: "API Error"
                 status: 400
                 detail: "The request is invalid or contains invalid parameters."
     AuthenticationError:
@@ -6463,7 +6443,7 @@ components:
             Unauthorized:
               value:
                 type: about:blank
-                title: "Unauthorized"
+                title: "API Error"
                 status: 401
                 detail: "Authentication credentials were missing or invalid."
     ForbiddenError:
@@ -6479,7 +6459,7 @@ components:
             Forbidden:
               value:
                 type: about:blank
-                title: "Forbidden"
+                title: "API Error"
                 status: 403
                 detail: "You do not have permission to access this resource."
     NotFoundError:
@@ -6495,7 +6475,7 @@ components:
             NotFound:
               value:
                 type: about:blank
-                title: "Not Found"
+                title: "API Error"
                 status: 404
                 detail: "The requested resource was not found."
     ConflictError:
@@ -6511,7 +6491,7 @@ components:
             Conflict:
               value:
                 type: about:blank
-                title: "Conflict"
+                title: "API Error"
                 status: 409
                 detail: "The request conflicts with the current state of the resource."
     GoneError:
@@ -6527,7 +6507,7 @@ components:
             Gone:
               value:
                 type: about:blank
-                title: "Gone"
+                title: "API Error"
                 status: 410
                 detail: "The resource is no longer available."
     PreconditionFailedError:
@@ -6543,7 +6523,7 @@ components:
             PreconditionFailed:
               value:
                 type: about:blank
-                title: "Precondition Failed"
+                title: "API Error"
                 status: 412
                 detail: "A precondition for the request was not met."
     InternalServerError:
@@ -6559,121 +6539,9 @@ components:
             InternalServerError:
               value:
                 type: about:blank
-                title: "Internal server error"
+                title: "API Error"
                 status: 500
                 detail: "The server encountered an error processing your request."
-    ConnectBadRequestError:
-      description: The request is invalid or contains invalid parameters
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            BadRequest:
-              value:
-                code: invalid_argument
-                message: "The request is invalid or contains invalid parameters."
-    ConnectAuthenticationError:
-      description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Unauthorized:
-              value:
-                code: unauthenticated
-                message: "Authentication credentials were missing or invalid."
-    ConnectForbiddenError:
-      description: Access denied
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Forbidden:
-              value:
-                code: permission_denied
-                message: "You do not have permission to access this resource."
-    ConnectNotFoundError:
-      description: Resource Not Found
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            NotFound:
-              value:
-                code: not_found
-                message: "The requested resource was not found."
-    ConnectConflictError:
-      description: Resource Conflicts
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Conflict:
-              value:
-                code: aborted
-                message: "The request conflicts with the current state of the resource."
-    ConnectGoneError:
-      description: Resource Gone or Expired
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Gone:
-              value:
-                code: not_found
-                message: "The resource is no longer available."
-    ConnectPreconditionFailedError:
-      description: Precondition Failed
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            PreconditionFailed:
-              value:
-                code: failed_precondition
-                message: "A precondition for the request was not met."
-    ConnectInternalServerError:
-      description: Internal Server Error
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            InternalServerError:
-              value:
-                code: internal
-                message: "The server encountered an error processing your request."
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -5407,6 +5407,11 @@ components:
           type: string
           description: A human-readable explanation specific to this occurrence.
           example: The request is invalid or contains invalid parameters.
+      example:
+        type: about:blank
+        title: Bad Request
+        status: 400
+        detail: The request is invalid or contains invalid parameters.
     ConnectError:
       type: object
       description: >-
@@ -5426,9 +5431,28 @@ components:
           example: The request was invalid.
         details:
           type: array
-          description: Optional structured error details.
+          description: Optional structured error details (e.g. google.rpc.ErrorInfo entries carrying the request id).
           items:
             type: object
+            properties:
+              type:
+                type: string
+                description: The fully-qualified type of the detail entry.
+                example: google.rpc.ErrorInfo
+              value:
+                type: string
+                description: Base64-encoded protobuf payload for the detail entry.
+              debug:
+                type: object
+                description: Human-readable debug metadata (omitted in production).
+      example:
+        code: invalid_argument
+        message: The request is invalid or contains invalid parameters.
+        details:
+          - type: google.rpc.ErrorInfo
+            debug:
+              metadata:
+                X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   headers:
     X-Request-Id:
       description: The unique identifier for the request

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -59,13 +59,13 @@ paths:
         "200":
           $ref: "#/components/responses/SearchOrganizationsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/organizations/{id}:
     get:
       summary: Get organization
@@ -95,15 +95,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/programs:
     get:
       summary: List Programs
@@ -133,13 +133,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListProgramsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/programs/{id}:
     get:
       summary: Get Program
@@ -169,15 +169,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Program"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/connects:
     post:
       summary: Create Connect
@@ -227,15 +227,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/ConnectOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/connects/{id}:
     get:
       summary: Get Connect
@@ -265,15 +265,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Connect"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/grants:
     get:
       summary: List Grants
@@ -308,13 +308,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     post:
       summary: Create Grant
       description: |-
@@ -413,15 +413,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/recurring_grants:
     get:
       summary: List Recurring Grants
@@ -456,13 +456,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListRecurringGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     post:
       summary: Create Recurring Grant
       description: |-
@@ -551,15 +551,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/RecurringGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/unintegrated_grants:
     get:
       summary: List Unintegrated Grants
@@ -594,13 +594,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListUnintegratedGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/unintegrated_grants/{id}:
     get:
       summary: Get Unintegrated Grant
@@ -636,15 +636,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/dafs:
     get:
       summary: List Donor Advised Funds
@@ -689,11 +689,11 @@ paths:
         "200":
           $ref: "#/components/responses/ListDafsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/dafs/{id}:
     get:
       summary: Get Donor Advised Fund
@@ -729,13 +729,13 @@ paths:
                 Npt:
                   $ref: "#/components/examples/DafOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/events:
     get:
       summary: List Events
@@ -771,13 +771,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/events/{id}:
     get:
       summary: Get Event
@@ -803,15 +803,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Event"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/event_subscriptions:
     post:
       summary: Create an Event Subscription
@@ -835,15 +835,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     get:
       summary: List Event Subscriptions
       description: |-
@@ -871,13 +871,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventSubscriptionsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/event_subscriptions/{id}:
     get:
       summary: Get an Event Subscription
@@ -903,15 +903,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     patch:
       summary: Update an Event Subscription
       description: |-
@@ -938,15 +938,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/financial_accounts:
     get:
       summary: List financial accounts
@@ -1062,15 +1062,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerificationRequest"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "409":
-          $ref: "#/components/responses/ConflictError"
+          $ref: "#/components/responses/ConnectConflictError"
         "412":
-          $ref: "#/components/responses/PreconditionFailedError"
+          $ref: "#/components/responses/ConnectPreconditionFailedError"
     get:
       summary: List verification requests
       description: |
@@ -1105,13 +1105,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListVerificationRequestsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/verification_requests/{id}:
     get:
       summary: Get a verification request
@@ -1140,13 +1140,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerificationRequest"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/disbursements:
     post:
       summary: Create a disbursement
@@ -1836,13 +1836,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListPaymentSourcesResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/payment_sources/{id}:
     get:
       summary: Get a Payment Source
@@ -1878,15 +1878,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/PaymentSource"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/donations:
     get:
       summary: List Donations
@@ -1943,13 +1943,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDonationsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/donations/{id}:
     get:
       summary: Get a Donation
@@ -1976,15 +1976,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Donation"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/deposits:
     get:
       summary: List Deposits
@@ -2034,13 +2034,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDepositsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/deposits/{id}:
     get:
       summary: Get a Deposit
@@ -2067,15 +2067,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Deposit"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/properties:
     get:
       summary: List Properties
@@ -2110,13 +2110,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListPropertiesResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/properties/{id}:
     get:
       summary: Get a Property
@@ -2143,15 +2143,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Property"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/properties/{id}/options:
     get:
       summary: List Property Options
@@ -2187,15 +2187,15 @@ paths:
         "200":
           $ref: "#/components/responses/ListPropertyOptionsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/properties/{id}/assign:
     post:
       summary: Assign a Property
@@ -2222,15 +2222,15 @@ paths:
         "200":
           $ref: "#/components/responses/AssignPropertyResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/mailbox/upload_url:
     post:
       summary: Get a Batch Upload URL
@@ -2321,13 +2321,13 @@ paths:
         "200":
           description: Indicates the PO box has been successfully provisioned.
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/nonprofit_addresses:
     post:
       summary: Create Nonprofit Addresses
@@ -2345,15 +2345,15 @@ paths:
         "200":
           description: All addresses were accepted.
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/nonprofit_contacts:
     post:
       summary: Create Nonprofit Contacts
@@ -2371,15 +2371,15 @@ paths:
         "200":
           description: All suggestions were accepted.
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
 components:
   securitySchemes:
     bearerAuth:
@@ -5378,30 +5378,57 @@ components:
           example: "eyJpZCI6IjEyMzQ1Njc4OTAiLCJ0aW1lc3RhbXAiOiIyMDIwLTA3LTEwIDE1OjAwOjAwLjAwMCJ9"
         total:
           type: integer
-    Error:
+    ProblemDetails:
       type: object
+      description: >-
+        RFC 7807 problem-details error (media type application/problem+json),
+        returned by resource and DAFpay endpoints. The `status` field is an
+        integer HTTP status code; it is unrelated to a resource's `status`
+        string (e.g. a grant's "Initiated"). Parse a body as a resource only on 2xx.
       required:
-        - timestamp
+        - type
+        - title
+        - status
+        - detail
+      properties:
+        type:
+          type: string
+          description: A URI reference identifying the problem type.
+          example: about:blank
+        title:
+          type: string
+          description: A short, human-readable summary of the problem type.
+          example: Bad Request
+        status:
+          type: integer
+          description: The HTTP status code for this error.
+          example: 400
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence.
+          example: The request is invalid or contains invalid parameters.
+    ConnectError:
+      type: object
+      description: >-
+        Connect (gRPC) error returned by the grantmaker read and query endpoints.
+        The `code` field is a machine-readable string code (not a number).
+      required:
         - code
-        - error
         - message
       properties:
-        timestamp:
-          type: string
-          description: time when the error was reported. Expressed in RFC 3339 format.
-          example: "2020-01-31T23:00:00Z"
         code:
-          type: number
-          description: HTTP status code of the error
-          example: 400
-        error:
           type: string
-          description: A short name of the error; usually the HTTP status.
-          example: Bad Request
+          description: The machine-readable Connect error code.
+          example: invalid_argument
         message:
           type: string
-          description: The description of the error
-          example: Expected an API key to be provided in the header `x-chariot-api-key`
+          description: A human-readable description of the error.
+          example: The request was invalid.
+        details:
+          type: array
+          description: Optional structured error details.
+          items:
+            type: object
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -6461,15 +6488,125 @@ components:
         X-Request-Id:
           $ref: "#/components/headers/X-Request-Id"
       content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Bad Request"
+            status: 400
+            detail: "The request is invalid or contains invalid parameters."
+    AuthenticationError:
+      description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Unauthorized"
+            status: 401
+            detail: "Authentication credentials were missing or invalid."
+    ForbiddenError:
+      description: Access denied
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Forbidden"
+            status: 403
+            detail: "You do not have permission to access this resource."
+    NotFoundError:
+      description: Resource Not Found
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Not Found"
+            status: 404
+            detail: "The requested resource was not found."
+    ConflictError:
+      description: Resource Conflicts
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Conflict"
+            status: 409
+            detail: "The request conflicts with the current state of the resource."
+    GoneError:
+      description: Resource Gone or Expired
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Gone"
+            status: 410
+            detail: "The resource is no longer available."
+    PreconditionFailedError:
+      description: Precondition Failed
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Precondition Failed"
+            status: 412
+            detail: "A precondition for the request was not met."
+    InternalServerError:
+      description: Internal Server Error
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Internal server error"
+            status: 500
+            detail: "The server encountered an error processing your request."
+    ConnectBadRequestError:
+      description: The request is invalid or contains invalid parameters
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 400
-            error: "Bad Request"
-            message: "Expected an API key to be provided in the header `x-chariot-api-key`"
-    AuthenticationError:
+            code: invalid_argument
+            message: "The request is invalid or contains invalid parameters."
+    ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
         X-Request-Id:
@@ -6477,13 +6614,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 401
-            error: "Unauthorized"
-            message: "Unauthorized"
-    ForbiddenError:
+            code: unauthenticated
+            message: "Authentication credentials were missing or invalid."
+    ConnectForbiddenError:
       description: Access denied
       headers:
         X-Request-Id:
@@ -6491,13 +6626,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 403
-            error: "Forbidden"
-            message: "User is not allowed to access this resource"
-    NotFoundError:
+            code: permission_denied
+            message: "You do not have permission to access this resource."
+    ConnectNotFoundError:
       description: Resource Not Found
       headers:
         X-Request-Id:
@@ -6505,13 +6638,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 404
-            error: "Not Found"
-            message: "Resource is not found"
-    ConflictError:
+            code: not_found
+            message: "The requested resource was not found."
+    ConnectConflictError:
       description: Resource Conflicts
       headers:
         X-Request-Id:
@@ -6519,13 +6650,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 409
-            error: "Conflict"
-            message: "Request conflicts with an already existing resource"
-    GoneError:
+            code: aborted
+            message: "The request conflicts with the current state of the resource."
+    ConnectGoneError:
       description: Resource Gone or Expired
       headers:
         X-Request-Id:
@@ -6533,13 +6662,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 410
-            error: "Gone"
-            message: "The resource has expired"
-    PreconditionFailedError:
+            code: not_found
+            message: "The resource is no longer available."
+    ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
         X-Request-Id:
@@ -6547,13 +6674,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 412
-            error: "Precondition Failed"
-            message: "The requested action has a failed precondition"
-    InternalServerError:
+            code: failed_precondition
+            message: "A precondition for the request was not met."
+    ConnectInternalServerError:
       description: Internal Server Error
       headers:
         X-Request-Id:
@@ -6561,12 +6686,10 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 500
-            error: "Internal server error"
-            message: "The server encountered an error processing your request"
+            code: internal
+            message: "The server encountered an error processing your request."
   examples:
     NonprofitRedCross:
       summary: American Red Cross

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -7735,34 +7735,19 @@ components:
                 type: string
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only substituting the pageToken with this value). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
-                    orgName: "National Philanthropic Trust"
-                    address: "123 Main St."
-                    address2: "Apt 100"
-                    city: "New York"
-                    state: "NY"
-                    zip: "12345"
-                    supported: true
-                    minimumGrantAmount: 5000
-                    institutionDown: false
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
-                    orgName: "National Philanthropic Trust"
-                    address: "123 Main St."
-                    address2: "Apt 100"
-                    city: "New York"
-                    state: "NY"
-                    zip: "12345"
-                    supported: true
-                    minimumGrantAmount: 5000
-                    institutionDown: false
+          example:
+            results:
+              - id: "0bf40881-8ee2-47fb-98ca-f58c7999aa34"
+                orgName: "National Philanthropic Trust"
+                address: "123 Main St."
+                address2: "Apt 100"
+                city: "New York"
+                state: "NY"
+                zip: "12345"
+                supported: true
+                minimumGrantAmount: 5000
+                institutionDown: false
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListDonorAccountsResponse:
       description: The response for DonorAccounts.list
       headers:
@@ -7782,43 +7767,24 @@ components:
                 nullable: true
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the page_token). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "donor_account_01jpjenf5q6cawy43yxfcrxhct"
-                    status: "approved"
-                    donor:
-                      email: "warrenBuffet@example.com"
-                      first_name: "Warren"
-                      last_name: "Buffet"
-                      phone: "+12125550100"
-                    external_id: "ACME-DAF-DONOR-1042"
-                    approval:
-                      approved_at: "2026-04-02T18:30:00Z"
-                      approved_by: "daf:fid_01jpjenf5q6cawy43yxfcrxhct"
-                    rejection: null
-                    disabled: false
-                    created_at: "2026-04-01T12:00:00Z"
-                    updated_at: "2026-04-02T18:30:00Z"
-                next_page_token: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "donor_account_01jpjenf5q6cawy43yxfcrxhct"
-                    status: "pending"
-                    donor:
-                      email: "warrenBuffet@example.com"
-                      first_name: null
-                      last_name: null
-                      phone: null
-                    external_id: null
-                    approval: null
-                    rejection: null
-                    disabled: false
-                    created_at: "2026-04-01T12:00:00Z"
-                    updated_at: "2026-04-01T12:00:00Z"
-                next_page_token: null
+          example:
+            results:
+              - id: "donor_account_01jpjenf5q6cawy43yxfcrxhct"
+                status: "approved"
+                donor:
+                  email: "warrenBuffet@example.com"
+                  first_name: "Warren"
+                  last_name: "Buffet"
+                  phone: "+12125550100"
+                external_id: "ACME-DAF-DONOR-1042"
+                approval:
+                  approved_at: "2026-04-02T18:30:00Z"
+                  approved_by: "daf:fid_01jpjenf5q6cawy43yxfcrxhct"
+                rejection: null
+                disabled: false
+                created_at: "2026-04-01T12:00:00Z"
+                updated_at: "2026-04-02T18:30:00Z"
+            next_page_token: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListDonorAuthorizationTokensResponse:
       description: The response for DonorAccounts.listAuthorizationTokens
       headers:
@@ -7868,29 +7834,16 @@ components:
                 nullable: true
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the pageToken). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                    status: "awaiting_daf_submission"
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 20000
-                    status: "Received"
-                nextPageToken: null
+          example:
+            results:
+              - id: "1e60800e-849b-43d1-870e-57afc8d75473"
+                workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+                status: "Initiated"
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListRecurringGrantsResponse:
       description: The response for RecurringGrants.list
       headers:
@@ -7909,28 +7862,16 @@ components:
                 type: string
                 description: |-
                   A cursor token to use to retrieve the next page of results by making another API call to the same endpoint with the same parameters (only changing the pageToken). If specified, then more results exist on the server that were not returned, otherwise no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "29650c10-1eb3-4f97-a63e-f2e41c145b53"
-                    workflowSessionId: "b76fa69f-c554-43b2-af9a-1d4bb9a02016"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                    frequency: MONTHLY
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "579e2864-d65a-4a21-a056-1c91d0a95b5c"
-                    workflowSessionId: "ee27b65b-22f5-42fa-b966-0f83cac8fd2c"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 16:00:00.000"
-                    updatedAt: "2021-08-11 15:25:00.000"
-                    amount: 20000
-                    frequency: MONTHLY
+          example:
+            results:
+              - id: "29650c10-1eb3-4f97-a63e-f2e41c145b53"
+                workflowSessionId: "b76fa69f-c554-43b2-af9a-1d4bb9a02016"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+                frequency: MONTHLY
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListUnintegratedGrantsResponse:
       description: The response for UnintegratedGrants.list
       headers:
@@ -7952,26 +7893,15 @@ components:
                    to the same endpoint with the same parameters (only changing the pageToken). If
                    specified, then more results exist on the server that were not returned, otherwise
                    no more results exist on the server.
-          examples:
-            MoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 15000
-                nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
-            NoMoreResults:
-              value:
-                results:
-                  - id: "1e60800e-849b-43d1-870e-57afc8d75473"
-                    workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
-                    fundId: "daf-id"
-                    createdAt: "2021-08-10 15:00:00.000"
-                    updatedAt: "2021-08-11 15:34:00.000"
-                    amount: 20000
+          example:
+            results:
+              - id: "1e60800e-849b-43d1-870e-57afc8d75473"
+                workflowSessionId: "cfe09e64-6a74-4dab-a565-361185a6f248"
+                fundId: "daf-id"
+                createdAt: "2021-08-10 15:00:00.000"
+                updatedAt: "2021-08-11 15:34:00.000"
+                amount: 15000
+            nextPageToken: "c3f685f2-2dda-4956-815b-39867a5e5638"
     ListEventsResponse:
       description: The response for Events.list
       headers:

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -8284,11 +8284,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Bad Request"
-            status: 400
-            detail: "The request is invalid or contains invalid parameters."
+          examples:
+            BadRequest:
+              value:
+                type: about:blank
+                title: "Bad Request"
+                status: 400
+                detail: "The request is invalid or contains invalid parameters."
     AuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -8298,11 +8300,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Unauthorized"
-            status: 401
-            detail: "Authentication credentials were missing or invalid."
+          examples:
+            Unauthorized:
+              value:
+                type: about:blank
+                title: "Unauthorized"
+                status: 401
+                detail: "Authentication credentials were missing or invalid."
     ForbiddenError:
       description: Access denied
       headers:
@@ -8312,11 +8316,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Forbidden"
-            status: 403
-            detail: "You do not have permission to access this resource."
+          examples:
+            Forbidden:
+              value:
+                type: about:blank
+                title: "Forbidden"
+                status: 403
+                detail: "You do not have permission to access this resource."
     NotFoundError:
       description: Resource Not Found
       headers:
@@ -8326,11 +8332,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Not Found"
-            status: 404
-            detail: "The requested resource was not found."
+          examples:
+            NotFound:
+              value:
+                type: about:blank
+                title: "Not Found"
+                status: 404
+                detail: "The requested resource was not found."
     ConflictError:
       description: Resource Conflicts
       headers:
@@ -8340,11 +8348,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Conflict"
-            status: 409
-            detail: "The request conflicts with the current state of the resource."
+          examples:
+            Conflict:
+              value:
+                type: about:blank
+                title: "Conflict"
+                status: 409
+                detail: "The request conflicts with the current state of the resource."
     GoneError:
       description: Resource Gone or Expired
       headers:
@@ -8354,11 +8364,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Gone"
-            status: 410
-            detail: "The resource is no longer available."
+          examples:
+            Gone:
+              value:
+                type: about:blank
+                title: "Gone"
+                status: 410
+                detail: "The resource is no longer available."
     PreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -8368,11 +8380,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Precondition Failed"
-            status: 412
-            detail: "A precondition for the request was not met."
+          examples:
+            PreconditionFailed:
+              value:
+                type: about:blank
+                title: "Precondition Failed"
+                status: 412
+                detail: "A precondition for the request was not met."
     InternalServerError:
       description: Internal Server Error
       headers:
@@ -8382,11 +8396,13 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/ProblemDetails"
-          example:
-            type: about:blank
-            title: "Internal server error"
-            status: 500
-            detail: "The server encountered an error processing your request."
+          examples:
+            InternalServerError:
+              value:
+                type: about:blank
+                title: "Internal server error"
+                status: 500
+                detail: "The server encountered an error processing your request."
     ConnectBadRequestError:
       description: The request is invalid or contains invalid parameters
       headers:
@@ -8396,9 +8412,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: invalid_argument
-            message: "The request is invalid or contains invalid parameters."
+          examples:
+            BadRequest:
+              value:
+                code: invalid_argument
+                message: "The request is invalid or contains invalid parameters."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -8408,9 +8431,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: unauthenticated
-            message: "Authentication credentials were missing or invalid."
+          examples:
+            Unauthorized:
+              value:
+                code: unauthenticated
+                message: "Authentication credentials were missing or invalid."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectForbiddenError:
       description: Access denied
       headers:
@@ -8420,9 +8450,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: permission_denied
-            message: "You do not have permission to access this resource."
+          examples:
+            Forbidden:
+              value:
+                code: permission_denied
+                message: "You do not have permission to access this resource."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectNotFoundError:
       description: Resource Not Found
       headers:
@@ -8432,9 +8469,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: not_found
-            message: "The requested resource was not found."
+          examples:
+            NotFound:
+              value:
+                code: not_found
+                message: "The requested resource was not found."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectConflictError:
       description: Resource Conflicts
       headers:
@@ -8444,9 +8488,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: aborted
-            message: "The request conflicts with the current state of the resource."
+          examples:
+            Conflict:
+              value:
+                code: aborted
+                message: "The request conflicts with the current state of the resource."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectGoneError:
       description: Resource Gone or Expired
       headers:
@@ -8456,9 +8507,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: not_found
-            message: "The resource is no longer available."
+          examples:
+            Gone:
+              value:
+                code: not_found
+                message: "The resource is no longer available."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -8468,9 +8526,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: failed_precondition
-            message: "A precondition for the request was not met."
+          examples:
+            PreconditionFailed:
+              value:
+                code: failed_precondition
+                message: "A precondition for the request was not met."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectInternalServerError:
       description: Internal Server Error
       headers:
@@ -8480,9 +8545,16 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ConnectError"
-          example:
-            code: internal
-            message: "The server encountered an error processing your request."
+          examples:
+            InternalServerError:
+              value:
+                code: internal
+                message: "The server encountered an error processing your request."
+                details:
+                  - type: google.rpc.ErrorInfo
+                    debug:
+                      metadata:
+                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   examples:
     DafGrantDisbursement:
       summary: Disbursement with DAF grant transactions

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -6823,10 +6823,10 @@ components:
     ProblemDetails:
       type: object
       description: >-
-        RFC 7807 problem-details error (media type application/problem+json),
-        returned by resource and DAFpay endpoints. The `status` field is an
-        integer HTTP status code; it is unrelated to a resource's `status`
-        string (e.g. a grant's "Initiated"). Parse a body as a resource only on 2xx.
+        RFC 7807 problem-details error (media type application/problem+json).
+        The `status` field is an integer HTTP status code; it is unrelated to a
+        resource's `status` string (e.g. a grant's "Initiated"). Parse a body as
+        a resource only on 2xx.
       required:
         - type
         - title
@@ -6857,8 +6857,8 @@ components:
     ConnectError:
       type: object
       description: >-
-        Connect (gRPC) error returned by the grantmaker read and query endpoints.
-        The `code` field is a machine-readable string code (not a number).
+        Connect (gRPC) error format. The `code` field is a machine-readable
+        string code (not a number).
       required:
         - code
         - message
@@ -6871,30 +6871,9 @@ components:
           type: string
           description: A human-readable description of the error.
           example: The request was invalid.
-        details:
-          type: array
-          description: Optional structured error details (e.g. google.rpc.ErrorInfo entries carrying the request id).
-          items:
-            type: object
-            properties:
-              type:
-                type: string
-                description: The fully-qualified type of the detail entry.
-                example: google.rpc.ErrorInfo
-              value:
-                type: string
-                description: Base64-encoded protobuf payload for the detail entry.
-              debug:
-                type: object
-                description: Human-readable debug metadata (omitted in production).
       example:
         code: invalid_argument
         message: The request is invalid or contains invalid parameters.
-        details:
-          - type: google.rpc.ErrorInfo
-            debug:
-              metadata:
-                X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -8347,11 +8326,6 @@ components:
               value:
                 code: invalid_argument
                 message: "The request is invalid or contains invalid parameters."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
@@ -8366,11 +8340,6 @@ components:
               value:
                 code: unauthenticated
                 message: "Authentication credentials were missing or invalid."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectForbiddenError:
       description: Access denied
       headers:
@@ -8385,11 +8354,6 @@ components:
               value:
                 code: permission_denied
                 message: "You do not have permission to access this resource."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectNotFoundError:
       description: Resource Not Found
       headers:
@@ -8404,11 +8368,6 @@ components:
               value:
                 code: not_found
                 message: "The requested resource was not found."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectConflictError:
       description: Resource Conflicts
       headers:
@@ -8423,11 +8382,6 @@ components:
               value:
                 code: aborted
                 message: "The request conflicts with the current state of the resource."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectGoneError:
       description: Resource Gone or Expired
       headers:
@@ -8442,11 +8396,6 @@ components:
               value:
                 code: not_found
                 message: "The resource is no longer available."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
@@ -8461,11 +8410,6 @@ components:
               value:
                 code: failed_precondition
                 message: "A precondition for the request was not met."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
     ConnectInternalServerError:
       description: Internal Server Error
       headers:
@@ -8480,11 +8424,6 @@ components:
               value:
                 code: internal
                 message: "The server encountered an error processing your request."
-                details:
-                  - type: google.rpc.ErrorInfo
-                    debug:
-                      metadata:
-                        X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   examples:
     DafGrantDisbursement:
       summary: Disbursement with DAF grant transactions

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -59,13 +59,13 @@ paths:
         "200":
           $ref: "#/components/responses/SearchOrganizationsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/organizations/{id}:
     get:
       summary: Get organization
@@ -95,15 +95,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/programs:
     get:
       summary: List Programs
@@ -133,13 +133,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListProgramsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/programs/{id}:
     get:
       summary: Get Program
@@ -169,15 +169,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Program"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/connects:
     post:
       summary: Create Connect
@@ -227,15 +227,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/ConnectOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/connects/{id}:
     get:
       summary: Get Connect
@@ -265,15 +265,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Connect"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/grants:
     get:
       summary: List Grants
@@ -318,13 +318,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     post:
       summary: Create Grant
       description: |-
@@ -423,15 +423,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/recurring_grants:
     get:
       summary: List Recurring Grants
@@ -466,13 +466,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListRecurringGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     post:
       summary: Create Recurring Grant
       description: |-
@@ -561,15 +561,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/RecurringGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/unintegrated_grants:
     get:
       summary: List Unintegrated Grants
@@ -604,13 +604,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListUnintegratedGrantsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/unintegrated_grants/{id}:
     get:
       summary: Get Unintegrated Grant
@@ -646,15 +646,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/dafs:
     get:
       summary: List Donor Advised Funds
@@ -699,11 +699,11 @@ paths:
         "200":
           $ref: "#/components/responses/ListDafsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/dafs/{id}:
     get:
       summary: Get Donor Advised Fund
@@ -739,13 +739,13 @@ paths:
                 Npt:
                   $ref: "#/components/examples/DafOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/donor_accounts:
     post:
       summary: Create Donor Account
@@ -848,13 +848,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDonorAccountsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/donor_accounts/{id}:
     get:
       summary: Get Donor Account
@@ -888,15 +888,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/DonorAccountOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     patch:
       summary: Update Donor Account
       description: |-
@@ -1515,13 +1515,13 @@ paths:
                         updated_at: "2026-03-21T09:30:00Z"
                     next_page_token: "c3f685f2-2dda-4956-815b-39867a5e5638"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/grant_requests/{id}:
     get:
       summary: Get Grant Request
@@ -1559,15 +1559,15 @@ paths:
                 Rejected:
                   $ref: "#/components/examples/GrantRequestRejectedOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/grant_requests/{id}/submit:
     post:
       summary: Submit Grant Request
@@ -1608,19 +1608,19 @@ paths:
                 Submitted:
                   $ref: "#/components/examples/GrantRequestSubmittedOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "409":
-          $ref: "#/components/responses/ConflictError"
+          $ref: "#/components/responses/ConnectConflictError"
         "412":
-          $ref: "#/components/responses/PreconditionFailedError"
+          $ref: "#/components/responses/ConnectPreconditionFailedError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/grant_requests/{id}/reject:
     post:
       summary: Reject Grant Request
@@ -1661,17 +1661,17 @@ paths:
                 Rejected:
                   $ref: "#/components/examples/GrantRequestRejectedOutput"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "409":
-          $ref: "#/components/responses/ConflictError"
+          $ref: "#/components/responses/ConnectConflictError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/events:
     get:
       summary: List Events
@@ -1707,13 +1707,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/events/{id}:
     get:
       summary: Get Event
@@ -1739,15 +1739,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Event"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/event_subscriptions:
     post:
       summary: Create an Event Subscription
@@ -1771,15 +1771,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     get:
       summary: List Event Subscriptions
       description: |-
@@ -1807,13 +1807,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventSubscriptionsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/event_subscriptions/{id}:
     get:
       summary: Get an Event Subscription
@@ -1839,15 +1839,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
     patch:
       summary: Update an Event Subscription
       description: |-
@@ -1874,15 +1874,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/financial_accounts:
     get:
       summary: List financial accounts
@@ -1998,15 +1998,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerificationRequest"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "409":
-          $ref: "#/components/responses/ConflictError"
+          $ref: "#/components/responses/ConnectConflictError"
         "412":
-          $ref: "#/components/responses/PreconditionFailedError"
+          $ref: "#/components/responses/ConnectPreconditionFailedError"
     get:
       summary: List verification requests
       description: |
@@ -2041,13 +2041,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListVerificationRequestsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/verification_requests/{id}:
     get:
       summary: Get a verification request
@@ -2076,13 +2076,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerificationRequest"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/disbursements:
     post:
       summary: Create a disbursement
@@ -2795,13 +2795,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListPaymentSourcesResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/payment_sources/{id}:
     get:
       summary: Get a Payment Source
@@ -2837,15 +2837,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/PaymentSource"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/donations:
     get:
       summary: List Donations
@@ -2902,13 +2902,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDonationsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/donations/{id}:
     get:
       summary: Get a Donation
@@ -2935,15 +2935,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Donation"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/deposits:
     get:
       summary: List Deposits
@@ -2993,13 +2993,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDepositsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/deposits/{id}:
     get:
       summary: Get a Deposit
@@ -3026,15 +3026,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Deposit"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/properties:
     get:
       summary: List Properties
@@ -3069,13 +3069,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListPropertiesResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/properties/{id}:
     get:
       summary: Get a Property
@@ -3102,15 +3102,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Property"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/properties/{id}/options:
     get:
       summary: List Property Options
@@ -3146,15 +3146,15 @@ paths:
         "200":
           $ref: "#/components/responses/ListPropertyOptionsResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/properties/{id}/assign:
     post:
       summary: Assign a Property
@@ -3181,15 +3181,15 @@ paths:
         "200":
           $ref: "#/components/responses/AssignPropertyResponse"
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/mailbox/upload_url:
     post:
       summary: Get a Batch Upload URL
@@ -3280,13 +3280,13 @@ paths:
         "200":
           description: Indicates the PO box has been successfully provisioned.
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/nonprofit_addresses:
     post:
       summary: Create Nonprofit Addresses
@@ -3304,15 +3304,15 @@ paths:
         "200":
           description: All addresses were accepted.
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
   /v1/nonprofit_contacts:
     post:
       summary: Create Nonprofit Contacts
@@ -3330,15 +3330,15 @@ paths:
         "200":
           description: All suggestions were accepted.
         "400":
-          $ref: "#/components/responses/BadRequestError"
+          $ref: "#/components/responses/ConnectBadRequestError"
         "401":
-          $ref: "#/components/responses/AuthenticationError"
+          $ref: "#/components/responses/ConnectAuthenticationError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/ConnectForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/ConnectNotFoundError"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          $ref: "#/components/responses/ConnectInternalServerError"
 components:
   securitySchemes:
     bearerAuth:
@@ -5099,7 +5099,7 @@ components:
         status:
           type: string
           description: The status of the grant
-          example: awaiting_daf_submission
+          example: Initiated
         feeDetail:
           type: object
           readOnly: true
@@ -6820,30 +6820,57 @@ components:
           example: "eyJpZCI6IjEyMzQ1Njc4OTAiLCJ0aW1lc3RhbXAiOiIyMDIwLTA3LTEwIDE1OjAwOjAwLjAwMCJ9"
         total:
           type: integer
-    Error:
+    ProblemDetails:
       type: object
+      description: >-
+        RFC 7807 problem-details error (media type application/problem+json),
+        returned by resource and DAFpay endpoints. The `status` field is an
+        integer HTTP status code; it is unrelated to a resource's `status`
+        string (e.g. a grant's "Initiated"). Parse a body as a resource only on 2xx.
       required:
-        - timestamp
+        - type
+        - title
+        - status
+        - detail
+      properties:
+        type:
+          type: string
+          description: A URI reference identifying the problem type.
+          example: about:blank
+        title:
+          type: string
+          description: A short, human-readable summary of the problem type.
+          example: Bad Request
+        status:
+          type: integer
+          description: The HTTP status code for this error.
+          example: 400
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence.
+          example: The request is invalid or contains invalid parameters.
+    ConnectError:
+      type: object
+      description: >-
+        Connect (gRPC) error returned by the grantmaker read and query endpoints.
+        The `code` field is a machine-readable string code (not a number).
+      required:
         - code
-        - error
         - message
       properties:
-        timestamp:
-          type: string
-          description: time when the error was reported. Expressed in RFC 3339 format.
-          example: "2020-01-31T23:00:00Z"
         code:
-          type: number
-          description: HTTP status code of the error
-          example: 400
-        error:
           type: string
-          description: A short name of the error; usually the HTTP status.
-          example: Bad Request
+          description: The machine-readable Connect error code.
+          example: invalid_argument
         message:
           type: string
-          description: The description of the error
-          example: Expected an API key to be provided in the header `x-chariot-api-key`
+          description: A human-readable description of the error.
+          example: The request was invalid.
+        details:
+          type: array
+          description: Optional structured error details.
+          items:
+            type: object
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -8230,15 +8257,125 @@ components:
         X-Request-Id:
           $ref: "#/components/headers/X-Request-Id"
       content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Bad Request"
+            status: 400
+            detail: "The request is invalid or contains invalid parameters."
+    AuthenticationError:
+      description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Unauthorized"
+            status: 401
+            detail: "Authentication credentials were missing or invalid."
+    ForbiddenError:
+      description: Access denied
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Forbidden"
+            status: 403
+            detail: "You do not have permission to access this resource."
+    NotFoundError:
+      description: Resource Not Found
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Not Found"
+            status: 404
+            detail: "The requested resource was not found."
+    ConflictError:
+      description: Resource Conflicts
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Conflict"
+            status: 409
+            detail: "The request conflicts with the current state of the resource."
+    GoneError:
+      description: Resource Gone or Expired
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Gone"
+            status: 410
+            detail: "The resource is no longer available."
+    PreconditionFailedError:
+      description: Precondition Failed
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Precondition Failed"
+            status: 412
+            detail: "A precondition for the request was not met."
+    InternalServerError:
+      description: Internal Server Error
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+          example:
+            type: about:blank
+            title: "Internal server error"
+            status: 500
+            detail: "The server encountered an error processing your request."
+    ConnectBadRequestError:
+      description: The request is invalid or contains invalid parameters
+      headers:
+        X-Request-Id:
+          $ref: "#/components/headers/X-Request-Id"
+      content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 400
-            error: "Bad Request"
-            message: "Expected an API key to be provided in the header `x-chariot-api-key`"
-    AuthenticationError:
+            code: invalid_argument
+            message: "The request is invalid or contains invalid parameters."
+    ConnectAuthenticationError:
       description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
       headers:
         X-Request-Id:
@@ -8246,13 +8383,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 401
-            error: "Unauthorized"
-            message: "Unauthorized"
-    ForbiddenError:
+            code: unauthenticated
+            message: "Authentication credentials were missing or invalid."
+    ConnectForbiddenError:
       description: Access denied
       headers:
         X-Request-Id:
@@ -8260,13 +8395,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 403
-            error: "Forbidden"
-            message: "User is not allowed to access this resource"
-    NotFoundError:
+            code: permission_denied
+            message: "You do not have permission to access this resource."
+    ConnectNotFoundError:
       description: Resource Not Found
       headers:
         X-Request-Id:
@@ -8274,13 +8407,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 404
-            error: "Not Found"
-            message: "Resource is not found"
-    ConflictError:
+            code: not_found
+            message: "The requested resource was not found."
+    ConnectConflictError:
       description: Resource Conflicts
       headers:
         X-Request-Id:
@@ -8288,13 +8419,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 409
-            error: "Conflict"
-            message: "Request conflicts with an already existing resource"
-    GoneError:
+            code: aborted
+            message: "The request conflicts with the current state of the resource."
+    ConnectGoneError:
       description: Resource Gone or Expired
       headers:
         X-Request-Id:
@@ -8302,13 +8431,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 410
-            error: "Gone"
-            message: "The resource has expired"
-    PreconditionFailedError:
+            code: not_found
+            message: "The resource is no longer available."
+    ConnectPreconditionFailedError:
       description: Precondition Failed
       headers:
         X-Request-Id:
@@ -8316,13 +8443,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 412
-            error: "Precondition Failed"
-            message: "The requested action has a failed precondition"
-    InternalServerError:
+            code: failed_precondition
+            message: "A precondition for the request was not met."
+    ConnectInternalServerError:
       description: Internal Server Error
       headers:
         X-Request-Id:
@@ -8330,12 +8455,10 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/ConnectError"
           example:
-            timestamp: "2020-01-31T23:00:00Z"
-            code: 500
-            error: "Internal server error"
-            message: "The server encountered an error processing your request"
+            code: internal
+            message: "The server encountered an error processing your request."
   examples:
     DafGrantDisbursement:
       summary: Disbursement with DAF grant transactions

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -59,13 +59,13 @@ paths:
         "200":
           $ref: "#/components/responses/SearchOrganizationsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/organizations/{id}:
     get:
       summary: Get organization
@@ -95,15 +95,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/programs:
     get:
       summary: List Programs
@@ -133,13 +133,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListProgramsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/programs/{id}:
     get:
       summary: Get Program
@@ -169,15 +169,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Program"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/connects:
     post:
       summary: Create Connect
@@ -227,15 +227,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/ConnectOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/connects/{id}:
     get:
       summary: Get Connect
@@ -265,15 +265,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Connect"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/grants:
     get:
       summary: List Grants
@@ -318,13 +318,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Grant
       description: |-
@@ -423,15 +423,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/GrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/recurring_grants:
     get:
       summary: List Recurring Grants
@@ -466,13 +466,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListRecurringGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     post:
       summary: Create Recurring Grant
       description: |-
@@ -561,15 +561,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/RecurringGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/unintegrated_grants:
     get:
       summary: List Unintegrated Grants
@@ -604,13 +604,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListUnintegratedGrantsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/unintegrated_grants/{id}:
     get:
       summary: Get Unintegrated Grant
@@ -646,15 +646,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/UnintegratedGrantOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/dafs:
     get:
       summary: List Donor Advised Funds
@@ -699,11 +699,11 @@ paths:
         "200":
           $ref: "#/components/responses/ListDafsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/dafs/{id}:
     get:
       summary: Get Donor Advised Fund
@@ -739,13 +739,13 @@ paths:
                 Npt:
                   $ref: "#/components/examples/DafOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/donor_accounts:
     post:
       summary: Create Donor Account
@@ -848,13 +848,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDonorAccountsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/donor_accounts/{id}:
     get:
       summary: Get Donor Account
@@ -888,15 +888,15 @@ paths:
                 Simple:
                   $ref: "#/components/examples/DonorAccountOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     patch:
       summary: Update Donor Account
       description: |-
@@ -1515,13 +1515,13 @@ paths:
                         updated_at: "2026-03-21T09:30:00Z"
                     next_page_token: "c3f685f2-2dda-4956-815b-39867a5e5638"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/grant_requests/{id}:
     get:
       summary: Get Grant Request
@@ -1559,15 +1559,15 @@ paths:
                 Rejected:
                   $ref: "#/components/examples/GrantRequestRejectedOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/grant_requests/{id}/submit:
     post:
       summary: Submit Grant Request
@@ -1608,19 +1608,19 @@ paths:
                 Submitted:
                   $ref: "#/components/examples/GrantRequestSubmittedOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "409":
-          $ref: "#/components/responses/ConnectConflictError"
+          $ref: "#/components/responses/ConflictError"
         "412":
-          $ref: "#/components/responses/ConnectPreconditionFailedError"
+          $ref: "#/components/responses/PreconditionFailedError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/grant_requests/{id}/reject:
     post:
       summary: Reject Grant Request
@@ -1661,17 +1661,17 @@ paths:
                 Rejected:
                   $ref: "#/components/examples/GrantRequestRejectedOutput"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "409":
-          $ref: "#/components/responses/ConnectConflictError"
+          $ref: "#/components/responses/ConflictError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/events:
     get:
       summary: List Events
@@ -1707,13 +1707,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/events/{id}:
     get:
       summary: Get Event
@@ -1739,15 +1739,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Event"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/event_subscriptions:
     post:
       summary: Create an Event Subscription
@@ -1771,15 +1771,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     get:
       summary: List Event Subscriptions
       description: |-
@@ -1807,13 +1807,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListEventSubscriptionsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/event_subscriptions/{id}:
     get:
       summary: Get an Event Subscription
@@ -1839,15 +1839,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
     patch:
       summary: Update an Event Subscription
       description: |-
@@ -1874,15 +1874,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventSubscription"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/financial_accounts:
     get:
       summary: List financial accounts
@@ -1998,15 +1998,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerificationRequest"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "409":
-          $ref: "#/components/responses/ConnectConflictError"
+          $ref: "#/components/responses/ConflictError"
         "412":
-          $ref: "#/components/responses/ConnectPreconditionFailedError"
+          $ref: "#/components/responses/PreconditionFailedError"
     get:
       summary: List verification requests
       description: |
@@ -2041,13 +2041,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListVerificationRequestsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/verification_requests/{id}:
     get:
       summary: Get a verification request
@@ -2076,13 +2076,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerificationRequest"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/disbursements:
     post:
       summary: Create a disbursement
@@ -2795,13 +2795,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListPaymentSourcesResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/payment_sources/{id}:
     get:
       summary: Get a Payment Source
@@ -2837,15 +2837,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/PaymentSource"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/donations:
     get:
       summary: List Donations
@@ -2902,13 +2902,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDonationsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/donations/{id}:
     get:
       summary: Get a Donation
@@ -2935,15 +2935,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Donation"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/deposits:
     get:
       summary: List Deposits
@@ -2993,13 +2993,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListDepositsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/deposits/{id}:
     get:
       summary: Get a Deposit
@@ -3026,15 +3026,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Deposit"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/properties:
     get:
       summary: List Properties
@@ -3069,13 +3069,13 @@ paths:
         "200":
           $ref: "#/components/responses/ListPropertiesResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/properties/{id}:
     get:
       summary: Get a Property
@@ -3102,15 +3102,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Property"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/properties/{id}/options:
     get:
       summary: List Property Options
@@ -3146,15 +3146,15 @@ paths:
         "200":
           $ref: "#/components/responses/ListPropertyOptionsResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/properties/{id}/assign:
     post:
       summary: Assign a Property
@@ -3181,15 +3181,15 @@ paths:
         "200":
           $ref: "#/components/responses/AssignPropertyResponse"
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/mailbox/upload_url:
     post:
       summary: Get a Batch Upload URL
@@ -3280,13 +3280,13 @@ paths:
         "200":
           description: Indicates the PO box has been successfully provisioned.
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/nonprofit_addresses:
     post:
       summary: Create Nonprofit Addresses
@@ -3304,15 +3304,15 @@ paths:
         "200":
           description: All addresses were accepted.
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
   /v1/nonprofit_contacts:
     post:
       summary: Create Nonprofit Contacts
@@ -3330,15 +3330,15 @@ paths:
         "200":
           description: All suggestions were accepted.
         "400":
-          $ref: "#/components/responses/ConnectBadRequestError"
+          $ref: "#/components/responses/BadRequestError"
         "401":
-          $ref: "#/components/responses/ConnectAuthenticationError"
+          $ref: "#/components/responses/AuthenticationError"
         "403":
-          $ref: "#/components/responses/ConnectForbiddenError"
+          $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/ConnectNotFoundError"
+          $ref: "#/components/responses/NotFoundError"
         "500":
-          $ref: "#/components/responses/ConnectInternalServerError"
+          $ref: "#/components/responses/InternalServerError"
 components:
   securitySchemes:
     bearerAuth:
@@ -6840,7 +6840,7 @@ components:
         title:
           type: string
           description: A short, human-readable summary of the problem type.
-          example: Bad Request
+          example: API Error
         status:
           type: integer
           description: The HTTP status code for this error.
@@ -6851,29 +6851,9 @@ components:
           example: The request is invalid or contains invalid parameters.
       example:
         type: about:blank
-        title: Bad Request
+        title: "API Error"
         status: 400
         detail: The request is invalid or contains invalid parameters.
-    ConnectError:
-      type: object
-      description: >-
-        Connect (gRPC) error format. The `code` field is a machine-readable
-        string code (not a number).
-      required:
-        - code
-        - message
-      properties:
-        code:
-          type: string
-          description: The machine-readable Connect error code.
-          example: invalid_argument
-        message:
-          type: string
-          description: A human-readable description of the error.
-          example: The request was invalid.
-      example:
-        code: invalid_argument
-        message: The request is invalid or contains invalid parameters.
   headers:
     X-Request-Id:
       description: The unique identifier for the request
@@ -8197,7 +8177,7 @@ components:
             BadRequest:
               value:
                 type: about:blank
-                title: "Bad Request"
+                title: "API Error"
                 status: 400
                 detail: "The request is invalid or contains invalid parameters."
     AuthenticationError:
@@ -8213,7 +8193,7 @@ components:
             Unauthorized:
               value:
                 type: about:blank
-                title: "Unauthorized"
+                title: "API Error"
                 status: 401
                 detail: "Authentication credentials were missing or invalid."
     ForbiddenError:
@@ -8229,7 +8209,7 @@ components:
             Forbidden:
               value:
                 type: about:blank
-                title: "Forbidden"
+                title: "API Error"
                 status: 403
                 detail: "You do not have permission to access this resource."
     NotFoundError:
@@ -8245,7 +8225,7 @@ components:
             NotFound:
               value:
                 type: about:blank
-                title: "Not Found"
+                title: "API Error"
                 status: 404
                 detail: "The requested resource was not found."
     ConflictError:
@@ -8261,7 +8241,7 @@ components:
             Conflict:
               value:
                 type: about:blank
-                title: "Conflict"
+                title: "API Error"
                 status: 409
                 detail: "The request conflicts with the current state of the resource."
     GoneError:
@@ -8277,7 +8257,7 @@ components:
             Gone:
               value:
                 type: about:blank
-                title: "Gone"
+                title: "API Error"
                 status: 410
                 detail: "The resource is no longer available."
     PreconditionFailedError:
@@ -8293,7 +8273,7 @@ components:
             PreconditionFailed:
               value:
                 type: about:blank
-                title: "Precondition Failed"
+                title: "API Error"
                 status: 412
                 detail: "A precondition for the request was not met."
     InternalServerError:
@@ -8309,121 +8289,9 @@ components:
             InternalServerError:
               value:
                 type: about:blank
-                title: "Internal server error"
+                title: "API Error"
                 status: 500
                 detail: "The server encountered an error processing your request."
-    ConnectBadRequestError:
-      description: The request is invalid or contains invalid parameters
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            BadRequest:
-              value:
-                code: invalid_argument
-                message: "The request is invalid or contains invalid parameters."
-    ConnectAuthenticationError:
-      description: Unauthorized. The request is missing the security (OAuth2 Bearer token) requirements and the server is unable to verify the identify of the caller.
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Unauthorized:
-              value:
-                code: unauthenticated
-                message: "Authentication credentials were missing or invalid."
-    ConnectForbiddenError:
-      description: Access denied
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Forbidden:
-              value:
-                code: permission_denied
-                message: "You do not have permission to access this resource."
-    ConnectNotFoundError:
-      description: Resource Not Found
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            NotFound:
-              value:
-                code: not_found
-                message: "The requested resource was not found."
-    ConnectConflictError:
-      description: Resource Conflicts
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Conflict:
-              value:
-                code: aborted
-                message: "The request conflicts with the current state of the resource."
-    ConnectGoneError:
-      description: Resource Gone or Expired
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            Gone:
-              value:
-                code: not_found
-                message: "The resource is no longer available."
-    ConnectPreconditionFailedError:
-      description: Precondition Failed
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            PreconditionFailed:
-              value:
-                code: failed_precondition
-                message: "A precondition for the request was not met."
-    ConnectInternalServerError:
-      description: Internal Server Error
-      headers:
-        X-Request-Id:
-          $ref: "#/components/headers/X-Request-Id"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ConnectError"
-          examples:
-            InternalServerError:
-              value:
-                code: internal
-                message: "The server encountered an error processing your request."
   examples:
     DafGrantDisbursement:
       summary: Disbursement with DAF grant transactions

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -6849,6 +6849,11 @@ components:
           type: string
           description: A human-readable explanation specific to this occurrence.
           example: The request is invalid or contains invalid parameters.
+      example:
+        type: about:blank
+        title: Bad Request
+        status: 400
+        detail: The request is invalid or contains invalid parameters.
     ConnectError:
       type: object
       description: >-
@@ -6868,9 +6873,28 @@ components:
           example: The request was invalid.
         details:
           type: array
-          description: Optional structured error details.
+          description: Optional structured error details (e.g. google.rpc.ErrorInfo entries carrying the request id).
           items:
             type: object
+            properties:
+              type:
+                type: string
+                description: The fully-qualified type of the detail entry.
+                example: google.rpc.ErrorInfo
+              value:
+                type: string
+                description: Base64-encoded protobuf payload for the detail entry.
+              debug:
+                type: object
+                description: Human-readable debug metadata (omitted in production).
+      example:
+        code: invalid_argument
+        message: The request is invalid or contains invalid parameters.
+        details:
+          - type: google.rpc.ErrorInfo
+            debug:
+              metadata:
+                X-Request-ID: 2d46f73e-24b6-43c6-bcbd-fa22415f697a
   headers:
     X-Request-Id:
       description: The unique identifier for the request

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -6824,9 +6824,7 @@ components:
       type: object
       description: >-
         RFC 7807 problem-details error (media type application/problem+json).
-        The `status` field is an integer HTTP status code; it is unrelated to a
-        resource's `status` string (e.g. a grant's "Initiated"). Parse a body as
-        a resource only on 2xx.
+        The `status` field is an integer HTTP status code.
       required:
         - type
         - title


### PR DESCRIPTION
## Problem (ENG-3996)

An integrator reported the grant `status` field coming back as an int "intermittently." Investigation found the error schema was documented wrong on **every** endpoint: all specs defined a single `Error` envelope — `{timestamp, code, error, message}` — that **no service returns**. The int the integrator saw was the error body's top-level `status` (an HTTP code) colliding by name with the grant resource's `status` **string** (`"Initiated"`).

## What clients actually receive (verified against production)

Every REST error response is **RFC 7807 problem+json** with a constant `title: "API Error"`:

```
$ curl -i https://api.givechariot.com/v1/grants
HTTP/2 401
content-type: application/problem+json
{"type":"about:blank","title":"API Error","status":401,"detail":"Unauthorized"}
```

This holds **even for the Connect/Vanguard-backed endpoints**: the shared `RESTErrorTranslator` middleware (`packages/connect-apis/server/http_middleware/rest_error_translator.go`) rewrites Connect errors into problem-details for REST callers. The native Connect `{code, message, details}` format is only returned to gRPC / `Connect-Protocol-Version` / dashboard clients, which don't use the RESTful `/v1/...` paths this spec documents. So there is effectively **one** client-facing error format.

## Changes (all 4 spec versions)

- Replace the fictional `Error` schema with **`ProblemDetails`** (`{type, title, status, detail}`) and document a single error format.
- Repoint every operation's error responses to the problem+json components; **remove** the `ConnectError` schema and all `Connect*Error` responses (not client-facing for REST consumers).
- Correct error example `title`s to the real constant **`"API Error"`**.
- Fix the `Grant.status` example: `awaiting_daf_submission` → `Initiated` (matches the live response).
- Collapse the dual `MoreResults` / `NoMoreResults` `200` examples on every list endpoint into a single example.
- Rewrite the **Error Codes** docs page to document the single problem+json format field-by-field.

`fern check` passes with 0 errors on all specs.

## Validation

Probed `api.givechariot.com` across both Connect-backed (`dafs`, `organizations`, `grants`, `deposits`, …) and REST (`disbursements`, `inbound_transfers`, …) endpoints — every error body is problem+json with `title: "API Error"`.

