### PR TITLE
chore: upgrade fern from 0.121.2 to 5.62.0

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "chariot",
-  "version": "0.121.2"
+  "version": "5.62.0"
 }


### PR DESCRIPTION
## Summary
- Upgrades Fern CLI from `0.121.2` to `5.62.0`
- Applied backwards-compatibility migrations to preserve existing behavior (smart-casing, enum coercion, request naming, generator API settings)

## Test plan
- [ ] Verify Fern generation still works as expected after upgrade