### PR TITLE
docs(openapi): document donation_id on grant resources

### DIFF
--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -5075,6 +5075,11 @@ components:
             Present on grants submitted by donors who authenticated through the DAFpay Donor Account flow.
             Grants submitted without a linked Donor Account will not have this field set.
           example: "donor_account_01jpjenf5q6cawy43yxfcrxhct"
+        donation_id:
+          type: string
+          readOnly: true
+          description: The ID of the donation initiated by this grant, if one exists.
+          example: "donation_01j8rs605a4gctmbm58d87mvsj"
         externalGrantId:
           type: string
           description: ID of the grant associated with the donor advised fund
@@ -5352,6 +5357,11 @@ components:
           readOnly: true
           description: ID of the donor advised fund
           example: daf-id
+        donation_id:
+          type: string
+          readOnly: true
+          description: The ID of the donation initiated by this grant, if one exists.
+          example: "donation_01j8rs605a4gctmbm58d87mvsj"
         createdAt:
           type: string
           readOnly: true

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -5078,7 +5078,9 @@ components:
         donation_id:
           type: string
           readOnly: true
-          description: The ID of the donation initiated by this grant, if one exists.
+          description: |-
+            The ID of the donation initiated by this grant, if one exists.
+            The donation is created asynchronously shortly after the grant is created, so this field is typically absent immediately after grant creation and populated a short time later.
           example: "donation_01j8rs605a4gctmbm58d87mvsj"
         externalGrantId:
           type: string
@@ -5360,7 +5362,9 @@ components:
         donation_id:
           type: string
           readOnly: true
-          description: The ID of the donation initiated by this grant, if one exists.
+          description: |-
+            The ID of the donation initiated by this grant, if one exists.
+            The donation is created asynchronously shortly after the grant is created, so this field is typically absent immediately after grant creation and populated a short time later.
           example: "donation_01j8rs605a4gctmbm58d87mvsj"
         createdAt:
           type: string


### PR DESCRIPTION
Documents the new `donation_id` field on the `Grant` and `UnintegratedGrant` resources (`2026-04-01` spec), matching the backend change in `chariot` (ENG-2217) that surfaces `donation_id` on grant resources.

`donation_id` is a read-only, optional string — the ID of the donation initiated by this grant, if one exists. Added only to the latest (`2026-04-01`) spec, consistent with how other recently-added fields (e.g. `donor_account_id`) are versioned.

`fern check` passes with 0 errors.