### PR TITLE
docs(api): correct property id examples to prop_ prefix (ENG-4515)

### DIFF
--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -2134,7 +2134,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
       responses:
         "200":
           description: The property was retrieved
@@ -2169,7 +2169,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
         - name: limit
           in: query
           description: Limit the size of the list that is returned. The default (and maximum) is 100 objects.
@@ -2215,7 +2215,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
       requestBody:
         $ref: "#/components/requestBodies/AssignPropertyRequest"
       responses:
@@ -3057,7 +3057,7 @@ components:
         property_id:
           type: string
           description: The unique identifier for the property.
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
         value:
           $ref: "#/components/schemas/PropertyValue"
     PropertyType:
@@ -3118,7 +3118,7 @@ components:
           type: string
           readOnly: true
           description: The unique identifier for the property.
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
         name:
           type: string
           description: The name of the property.

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -3093,7 +3093,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
       responses:
         "200":
           description: The property was retrieved
@@ -3128,7 +3128,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
         - name: limit
           in: query
           description: Limit the size of the list that is returned. The default (and maximum) is 100 objects.
@@ -3174,7 +3174,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
       requestBody:
         $ref: "#/components/requestBodies/AssignPropertyRequest"
       responses:
@@ -4016,7 +4016,7 @@ components:
         property_id:
           type: string
           description: The unique identifier for the property.
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
         value:
           $ref: "#/components/schemas/PropertyValue"
     PropertyType:
@@ -4077,7 +4077,7 @@ components:
           type: string
           readOnly: true
           description: The unique identifier for the property.
-          example: "property_01j8rs605a4gctmbm58d87mvsj"
+          example: "prop_01j8rs605a4gctmbm58d87mvsj"
         name:
           type: string
           description: The name of the property.


### PR DESCRIPTION
The property id examples used the `property_` prefix, but the real cuid
prefix is `prop_`. Fern rendered the invalid example in "Try it", causing
failed AssignProperty calls. Fix the examples on the property endpoints and
schemas across the 2026-04-01 and 2026-01-15 specs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>