### PR TITLE
docs(sandbox): document organization onboarding for disbursement rails

### DIFF
--- a/fern/apis/2026-01-15/openapi-overrides.yml
+++ b/fern/apis/2026-01-15/openapi-overrides.yml
@@ -13,6 +13,11 @@ paths:
       x-fern-sdk-group-name:
         - organizations
       x-fern-sdk-method-name: get
+  /v1/simulations/organizations/onboard/{id}:
+    post:
+      x-fern-sdk-group-name:
+        - organizations
+      x-fern-sdk-method-name: onboard
   /v1/programs:
     get:
       x-fern-pagination:

--- a/fern/apis/2026-04-01/openapi-overrides.yml
+++ b/fern/apis/2026-04-01/openapi-overrides.yml
@@ -13,6 +13,11 @@ paths:
       x-fern-sdk-group-name:
         - organizations
       x-fern-sdk-method-name: get
+  /v1/simulations/organizations/onboard/{id}:
+    post:
+      x-fern-sdk-group-name:
+        - organizations
+      x-fern-sdk-method-name: onboard
   /v1/programs:
     get:
       x-fern-pagination:

--- a/fern/versions/v2026-01-15/pages/disbursements/sandbox.mdx
+++ b/fern/versions/v2026-01-15/pages/disbursements/sandbox.mdx
@@ -14,15 +14,32 @@ These APIs allow you to quickly test financial related events that might take lo
 
 If you have a sandbox Event Subscription configured, calling these APIs will also result in the appropriate webhooks being sent to your endpoint.
 
-## Sandbox Lifecycle
+## Testing disbursement payment rails
 
-To adequately test the various [disbursement payment rails](/guides/disbursements/disbursement-lifecycle#payment-rail-lifecycle) (Account, ACH, Check), 
-you'll need to make use of a fixed set of test nonprofit Organizations that have been pre-configured in the Sandbox environment.
+Which [payment rail](/guides/disbursements/disbursement-lifecycle#payment-rail-lifecycle) a disbursement settles on depends on whether the recipient
+organization has a Chariot account. An organization without a Chariot account is paid by [mailed check](/guides/disbursements/disbursement-lifecycle#mailed-check);
+an organization with one is paid electronically.
 
-The following Organizations will allow you test the various disbursement payment rails:
+In Sandbox, an organization you disburse to has no Chariot account by default, so its disbursements settle as a check. To test the electronic rails,
+onboard the organization first with the [Onboard Organization](/api/organizations/onboard) simulation. Onboarding provisions a Chariot account for the
+organization and lets you choose which electronic rail its disbursements settle on:
 
-| EIN | Transfer Type |
-| --- | ------------ |
-| 752456162 | [Account transfer](/guides/disbursements/disbursement-lifecycle#account-transfer) |
-| 861649851 | [ACH transfer](/guides/disbursements/disbursement-lifecycle#ach) |
-| 132555281 | [Check transfer](/guides/disbursements/disbursement-lifecycle#mailed-check) |
+| `settlement` | Payment rail |
+| --- | --- |
+| `SANDBOX_SETTLEMENT_ACCOUNT_TRANSFER` | [Account transfer](/guides/disbursements/disbursement-lifecycle#account-transfer) |
+| `SANDBOX_SETTLEMENT_ACH` | [ACH transfer](/guides/disbursements/disbursement-lifecycle#ach) |
+
+<EndpointRequestSnippet endpoint="POST /v1/simulations/organizations/onboard/{id}" />
+
+To test the [check](/guides/disbursements/disbursement-lifecycle#mailed-check) rail, simply disburse to an organization you have not onboarded.
+
+<Note>
+The `settlement` is fixed the first time you onboard an organization. Once an organization has been onboarded, its disbursements settle on the chosen
+rail even if you later intend to test a different one. To exercise another rail, onboard a different organization.
+</Note>
+
+<Warning title="Deprecated">
+Earlier versions of the Sandbox relied on a fixed set of pre-configured test organizations (EINs `752456162`, `861649851`, and `132555281`) to
+exercise the different payment rails. These are being deprecated in favor of onboarding organizations programmatically with the
+[Onboard Organization](/api/organizations/onboard) simulation, which works for any organization and any tenant.
+</Warning>

--- a/fern/versions/v2026-01-15/pages/disbursements/sandbox.mdx
+++ b/fern/versions/v2026-01-15/pages/disbursements/sandbox.mdx
@@ -41,5 +41,5 @@ rail even if you later intend to test a different one. To exercise another rail,
 <Warning title="Deprecated">
 Earlier versions of the Sandbox relied on a fixed set of pre-configured test organizations (EINs `752456162`, `861649851`, and `132555281`) to
 exercise the different payment rails. These are being deprecated in favor of onboarding organizations programmatically with the
-[Onboard Organization](/api/organizations/onboard) simulation, which works for any organization and any tenant.
+[Onboard Organization](/api/organizations/onboard) simulation, which works for any organization.
 </Warning>

--- a/fern/versions/v2026-04-01/pages/disbursements/sandbox.mdx
+++ b/fern/versions/v2026-04-01/pages/disbursements/sandbox.mdx
@@ -14,15 +14,32 @@ These APIs allow you to quickly test financial related events that might take lo
 
 If you have a sandbox Event Subscription configured, calling these APIs will also result in the appropriate webhooks being sent to your endpoint.
 
-## Sandbox Lifecycle
+## Testing disbursement payment rails
 
-To adequately test the various [disbursement payment rails](/guides/disbursements/disbursement-lifecycle#payment-rail-lifecycle) (Account, ACH, Check), 
-you'll need to make use of a fixed set of test nonprofit Organizations that have been pre-configured in the Sandbox environment.
+Which [payment rail](/guides/disbursements/disbursement-lifecycle#payment-rail-lifecycle) a disbursement settles on depends on whether the recipient
+organization has a Chariot account. An organization without a Chariot account is paid by [mailed check](/guides/disbursements/disbursement-lifecycle#mailed-check);
+an organization with one is paid electronically.
 
-The following Organizations will allow you test the various disbursement payment rails:
+In Sandbox, an organization you disburse to has no Chariot account by default, so its disbursements settle as a check. To test the electronic rails,
+onboard the organization first with the [Onboard Organization](/api/organizations/onboard) simulation. Onboarding provisions a Chariot account for the
+organization and lets you choose which electronic rail its disbursements settle on:
 
-| EIN | Transfer Type |
-| --- | ------------ |
-| 752456162 | [Account transfer](/guides/disbursements/disbursement-lifecycle#account-transfer) |
-| 861649851 | [ACH transfer](/guides/disbursements/disbursement-lifecycle#ach) |
-| 132555281 | [Check transfer](/guides/disbursements/disbursement-lifecycle#mailed-check) |
+| `settlement` | Payment rail |
+| --- | --- |
+| `SANDBOX_SETTLEMENT_ACCOUNT_TRANSFER` | [Account transfer](/guides/disbursements/disbursement-lifecycle#account-transfer) |
+| `SANDBOX_SETTLEMENT_ACH` | [ACH transfer](/guides/disbursements/disbursement-lifecycle#ach) |
+
+<EndpointRequestSnippet endpoint="POST /v1/simulations/organizations/onboard/{id}" />
+
+To test the [check](/guides/disbursements/disbursement-lifecycle#mailed-check) rail, simply disburse to an organization you have not onboarded.
+
+<Note>
+The `settlement` is fixed the first time you onboard an organization. Once an organization has been onboarded, its disbursements settle on the chosen
+rail even if you later intend to test a different one. To exercise another rail, onboard a different organization.
+</Note>
+
+<Warning title="Deprecated">
+Earlier versions of the Sandbox relied on a fixed set of pre-configured test organizations (EINs `752456162`, `861649851`, and `132555281`) to
+exercise the different payment rails. These are being deprecated in favor of onboarding organizations programmatically with the
+[Onboard Organization](/api/organizations/onboard) simulation, which works for any organization and any tenant.
+</Warning>

--- a/fern/versions/v2026-04-01/pages/disbursements/sandbox.mdx
+++ b/fern/versions/v2026-04-01/pages/disbursements/sandbox.mdx
@@ -41,5 +41,5 @@ rail even if you later intend to test a different one. To exercise another rail,
 <Warning title="Deprecated">
 Earlier versions of the Sandbox relied on a fixed set of pre-configured test organizations (EINs `752456162`, `861649851`, and `132555281`) to
 exercise the different payment rails. These are being deprecated in favor of onboarding organizations programmatically with the
-[Onboard Organization](/api/organizations/onboard) simulation, which works for any organization and any tenant.
+[Onboard Organization](/api/organizations/onboard) simulation, which works for any organization.
 </Warning>

--- a/fern/versions/v2026-04-01/pages/disbursements/sandbox.mdx
+++ b/fern/versions/v2026-04-01/pages/disbursements/sandbox.mdx
@@ -21,7 +21,7 @@ organization has a Chariot account. An organization without a Chariot account is
 an organization with one is paid electronically.
 
 In Sandbox, an organization you disburse to has no Chariot account by default, so its disbursements settle as a check. To test the electronic rails,
-onboard the organization first with the [Onboard Organization](/api/organizations/onboard) simulation. Onboarding provisions a Chariot account for the
+onboard the organization first with the [Simulate Onboard Organization](/api/organizations/onboard) simulation. Onboarding provisions a Chariot account for the
 organization and lets you choose which electronic rail its disbursements settle on:
 
 | `settlement` | Payment rail |

--- a/specs/2026-01-15.yaml
+++ b/specs/2026-01-15.yaml
@@ -104,6 +104,68 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/organizations/onboard/{id}:
+    post:
+      summary: "Sandbox: Onboard an organization"
+      description: |
+        Creates a Chariot account for a sandbox recipient organization so that
+        disbursements to it settle electronically instead of via a mailed check.
+
+        By default a sandbox organization has no Chariot account, so disbursements
+        to it are mailed as a physical check. Call this endpoint to provision an
+        account for the organization and choose which electronic rail its
+        disbursements should settle on.
+
+        The `settlement` is fixed on the first successful call. Onboarding the same
+        organization again with a different `settlement` returns an error.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: onboardOrganization
+      tags:
+        - Organizations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier for the organization to onboard.
+          required: true
+          schema:
+            type: string
+          example: "org_1LaXpKGUcADgqoEMl0Cx0Ygg"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - settlement
+              properties:
+                settlement:
+                  $ref: "#/components/schemas/SandboxSettlement"
+      responses:
+        "200":
+          description: "OK"
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/X-Request-Id"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Organization"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/programs:
     get:
       summary: List Programs
@@ -2419,6 +2481,16 @@ components:
           type: string
           description: The state of the organization.
           example: NY
+    SandboxSettlement:
+      type: string
+      description: |-
+        The electronic rail on which disbursements to an onboarded sandbox
+        organization settle. `SANDBOX_SETTLEMENT_ACCOUNT_TRANSFER` settles as an
+        in-network transfer between accounts on the same bank. `SANDBOX_SETTLEMENT_ACH`
+        settles via ACH across banks.
+      enum:
+        - SANDBOX_SETTLEMENT_ACCOUNT_TRANSFER
+        - SANDBOX_SETTLEMENT_ACH
     Organization:
       type: object
       description: |-

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -104,6 +104,68 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/organizations/onboard/{id}:
+    post:
+      summary: "Sandbox: Onboard an organization"
+      description: |
+        Creates a Chariot account for a sandbox recipient organization so that
+        disbursements to it settle electronically instead of via a mailed check.
+
+        By default a sandbox organization has no Chariot account, so disbursements
+        to it are mailed as a physical check. Call this endpoint to provision an
+        account for the organization and choose which electronic rail its
+        disbursements should settle on.
+
+        The `settlement` is fixed on the first successful call. Onboarding the same
+        organization again with a different `settlement` returns an error.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: onboardOrganization
+      tags:
+        - Organizations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier for the organization to onboard.
+          required: true
+          schema:
+            type: string
+          example: "org_1LaXpKGUcADgqoEMl0Cx0Ygg"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - settlement
+              properties:
+                settlement:
+                  $ref: "#/components/schemas/SandboxSettlement"
+      responses:
+        "200":
+          description: "OK"
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/X-Request-Id"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Organization"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/programs:
     get:
       summary: List Programs
@@ -3378,6 +3440,16 @@ components:
           type: string
           description: The state of the organization.
           example: NY
+    SandboxSettlement:
+      type: string
+      description: |-
+        The electronic rail on which disbursements to an onboarded sandbox
+        organization settle. `SANDBOX_SETTLEMENT_ACCOUNT_TRANSFER` settles as an
+        in-network transfer between accounts on the same bank. `SANDBOX_SETTLEMENT_ACH`
+        settles via ACH across banks.
+      enum:
+        - SANDBOX_SETTLEMENT_ACCOUNT_TRANSFER
+        - SANDBOX_SETTLEMENT_ACH
     Organization:
       type: object
       description: |-


### PR DESCRIPTION
Our sandbox disbursement docs no longer match how sandbox tenants actually behave.

The docs tell customers to disburse to a fixed set of pre-configured test EINs to exercise the account/ACH/check rails. That was true when those orgs were baked into the seed data, but new sandbox tenants get their recipient orgs created lazily on first disbursement, and those orgs have no Chariot account. With no account, everything settles as a mailed check regardless of which "rail" EIN you pick, so the table is misleading for anyone onboarded after the change.

The real lever now is the OnboardOrganization simulation. Onboarding provisions a Chariot account for a recipient org and lets the caller choose the electronic settlement rail. This change documents that endpoint (adds it to the OpenAPI specs so a reference page renders, wires the SDK group/method), and rewrites the sandbox guide to explain that unonboarded orgs pay by check while onboarded orgs pay electronically. The static-EIN table is marked deprecated with a pointer to the new API.

Applied to both currently published versions (2026-04-01 and 2026-01-15). Draft because the settlement enum / behavior should get a second look, and we may want a follow-up on surfacing this in the dashboard sandbox for non-API users.