### PR TITLE
docs(sandbox): document deposit simulation routes

### DIFF
--- a/fern/versions/v2026-04-01/docs.yml
+++ b/fern/versions/v2026-04-01/docs.yml
@@ -128,6 +128,9 @@ navigation:
           - page: Getting Started
             slug: getting-started
             path: ./pages/processing/getting-started.mdx
+          - page: Sandbox
+            slug: sandbox
+            path: ./pages/processing/sandbox.mdx
           - page: FAQ
             slug: faq
             path: ./pages/processing/faq.mdx

--- a/fern/versions/v2026-04-01/pages/processing/sandbox.mdx
+++ b/fern/versions/v2026-04-01/pages/processing/sandbox.mdx
@@ -1,0 +1,58 @@
+---
+title: "Sandbox"
+subtitle: "Simulate donations and deposits so a sandbox account looks and settles like a real one."
+hidden: false
+---
+
+In production, a gift shows up on a payment source as two things that have to line up: a donation (who gave, how much, and why) and a deposit (the money itself landing in your account). Chariot reconciles them and the donation settles.
+
+In the sandbox you can drive that same flow on demand, without waiting on a real donor or bank. The Simulate a Donation and Simulate a Deposit endpoints create each half through the same pipeline a real gift uses, and a shared handle ties them together.
+
+<Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+These endpoints are only available in the sandbox environment.
+</Note>
+
+## The simulation batch id
+
+`simulation_batch_id` is the handle that links a donation to the deposit that funds it. In production, incoming money and its donations are matched by an identifier the bank or platform assigns to a batch of transactions; in the sandbox you set that identifier yourself.
+
+A few things to know:
+
+- When you simulate a donation or a deposit, the response returns a `simulation_batch_id`. If you did not pass one, Chariot generates it for you.
+- Pass the same value to the other half of the flow to reconcile them together. A donation and a deposit that share a batch id settle against each other.
+- Order does not matter. You can simulate the deposit first and the donation second, or the other way around; they reconcile whenever both exist.
+- You can group several donations under one batch id so a single deposit settles all of them at once.
+- Persist the value when you get it back. It cannot be read off the donation or deposit afterward, and you need it to link the two halves.
+- It is capped at 17 characters.
+
+## Walkthrough
+
+### 1. Simulate a donation
+
+Create the donation half of the gift. The only required fields are the payment source it arrives on and the gross amount; everything else (donor, DAF grant, corporate match, note) is optional detail that makes the record look realistic.
+
+<EndpointRequestSnippet endpoint="POST /v1/simulations/donations" />
+
+The response includes a `donation_id` and a `simulation_batch_id`. Hold onto the batch id for the next step.
+
+### 2. Simulate the deposit that funds it
+
+Create the deposit half, passing the `simulation_batch_id` from step 1 so the money lands against the donation you just made. The deposit arrives in a pending state, the same as a real one that has not cleared yet.
+
+<EndpointRequestSnippet endpoint="POST /v1/simulations/deposits" />
+
+### 3. Clear or bounce the deposit
+
+A pending deposit sits until its funds either clear or come back. Simulate whichever outcome you want to test.
+
+Completing it makes the funds available and marks the reconciled donations as received:
+
+<EndpointRequestSnippet endpoint="POST /v1/simulations/deposits/{id}/complete" />
+
+Failing it acts like a returned payment (for example, a bounced check) and reverses the reconciled donations:
+
+<EndpointRequestSnippet endpoint="POST /v1/simulations/deposits/{id}/fail" />
+
+<Note>
+If you have a sandbox Event Subscription configured, these simulations emit the same webhooks a real donation and deposit would, so you can test your event handling end to end.
+</Note>

--- a/fern/versions/v2026-04-01/pages/processing/sandbox.mdx
+++ b/fern/versions/v2026-04-01/pages/processing/sandbox.mdx
@@ -6,20 +6,15 @@ hidden: false
 
 In production, a gift shows up on a payment source as two things that have to line up: a donation (who gave, how much, and why) and a deposit (the money itself landing in your account). Chariot reconciles them and the donation settles.
 
-In the sandbox you can drive that same flow on demand, without waiting on a real donor or bank. The Simulate a Donation and Simulate a Deposit endpoints create each half through the same pipeline a real gift uses, and a shared handle ties them together.
+In the sandbox, you can drive that same flow on demand. The Simulate a Donation and Simulate a Deposit endpoints create each half, and a shared identifier ties them together.
 
 ## The simulation batch id
 
-`simulation_batch_id` is the handle that links a donation to the deposit that funds it. In production, incoming money and its donations are matched by an identifier the bank or platform assigns to a batch of transactions; in the sandbox you set that identifier yourself.
+The `simulation_batch_id` is the identifier that links a donation to the deposit that funds it. In production, incoming money and its donations are matched automatically by our system; in the sandbox you set that identifier yourself.
 
-A few things to know:
+When you simulate a donation or a deposit, the response returns a `simulation_batch_id`. If you did not pass one, Chariot generates it for you. Pass the same value to the other half of the flow to reconcile them together. Persist the value when you get it back. It cannot be read off the donation or deposit afterward, and you need it to link the two halves.
 
-- When you simulate a donation or a deposit, the response returns a `simulation_batch_id`. If you did not pass one, Chariot generates it for you.
-- Pass the same value to the other half of the flow to reconcile them together. A donation and a deposit that share a batch id settle against each other.
-- Order does not matter. You can simulate the deposit first and the donation second, or the other way around; they reconcile whenever both exist.
-- You can group several donations under one batch id so a single deposit settles all of them at once.
-- Persist the value when you get it back. It cannot be read off the donation or deposit afterward, and you need it to link the two halves.
-- It is capped at 17 characters.
+The order of operations does not matter. You can simulate the deposit first and the donation second, or the other way around. They reconcile whenever both exist. You can group several donations under one batch id so a single deposit settles all of them at once.
 
 ## Walkthrough
 

--- a/fern/versions/v2026-04-01/pages/processing/sandbox.mdx
+++ b/fern/versions/v2026-04-01/pages/processing/sandbox.mdx
@@ -8,10 +8,6 @@ In production, a gift shows up on a payment source as two things that have to li
 
 In the sandbox you can drive that same flow on demand, without waiting on a real donor or bank. The Simulate a Donation and Simulate a Deposit endpoints create each half through the same pipeline a real gift uses, and a shared handle ties them together.
 
-<Note title="Sandbox Only" icon="fa-light fa-atom-simple">
-These endpoints are only available in the sandbox environment.
-</Note>
-
 ## The simulation batch id
 
 `simulation_batch_id` is the handle that links a donation to the deposit that funds it. In production, incoming money and its donations are matched by an identifier the bank or platform assigns to a batch of transactions; in the sandbox you set that identifier yourself.

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2900,6 +2900,133 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/deposits:
+    post:
+      summary: "Sandbox: Simulate a Deposit"
+      description: |-
+        Simulate a deposit arriving on a payment source.
+        The deposit is created asynchronously through the standard processing pipeline.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: simulateDeposit
+      tags:
+        - deposits
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - payment_source_id
+                - amount
+              properties:
+                payment_source_id:
+                  type: string
+                  description: The payment source the deposit should arrive on.
+                  example: "payment_source_01j8rs605a4gctmbm58d87mvsj"
+                amount:
+                  type: string
+                  format: int64
+                  description: The deposit amount in cents. Must be positive.
+                  example: "5000"
+                idempotency_key:
+                  type: string
+                  description: Optional idempotency key. When set, repeating the call does not create a second deposit. When empty, every call creates a new deposit.
+                simulation_batch_id:
+                  type: string
+                  description: Groups this deposit with simulated donations so it reconciles against them, standing in for the ACH batch the bank would otherwise assign. Leave empty to mint a fresh one, or set it to the simulation_batch_id of one or more simulated donations. Capped at 17 characters.
+      responses:
+        "202":
+          description: The deposit simulation request was accepted
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/deposits/{id}/complete:
+    post:
+      summary: "Sandbox: Complete a Deposit"
+      description: |-
+        Advances a pending deposit to complete, as though the bank cleared its incoming transfer (e.g. a mailed check clearing).
+        Its funds become available and its donations become received.
+        The state change settles asynchronously through the standard processing pipeline.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: simulateDepositCompletion
+      tags:
+        - deposits
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier for the deposit
+          required: true
+          schema:
+            type: string
+          example: "deposit_01j8rs605a4gctmbm58d87mvsj"
+      responses:
+        "202":
+          description: The deposit completion request was accepted
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/deposits/{id}/fail:
+    post:
+      summary: "Sandbox: Fail a Deposit"
+      description: |-
+        Advances a pending deposit to failed, as though its incoming transfer was returned (e.g. a mailed check bouncing).
+        Its donations are reversed.
+        The state change settles asynchronously through the standard processing pipeline.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: simulateDepositFailure
+      tags:
+        - deposits
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier for the deposit
+          required: true
+          schema:
+            type: string
+          example: "deposit_01j8rs605a4gctmbm58d87mvsj"
+      responses:
+        "202":
+          description: The deposit failure request was accepted
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/payment_sources:
     get:
       summary: List Payment Sources

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2900,12 +2900,97 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/donations:
+    post:
+      summary: "Sandbox: Simulate a Donation"
+      description: |-
+        Simulate a donation arriving on a payment source, the same way a real gift from a connected platform would.
+
+        The response returns a `simulation_batch_id`. Pass that value to the Simulate a Deposit endpoint (or to another Simulate a Donation call) to group them together, so the donation reconciles and settles against that deposit's funds. Order does not matter: you can create the deposit or the donation first.
+
+        See [Simulating gift processing](/guides/processing/sandbox) for a full walkthrough.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: simulateDonation
+      tags:
+        - donations
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - payment_source_id
+                - amount_gross
+              properties:
+                payment_source_id:
+                  type: string
+                  description: The payment source the donation is arriving on.
+                  example: "payment_source_01j8rs605a4gctmbm58d87mvsj"
+                amount_gross:
+                  type: string
+                  format: int64
+                  description: The gross gift amount, in the smallest currency unit (for example, cents). Must be positive.
+                  example: "5000"
+                amount_fee:
+                  type: string
+                  format: int64
+                  description: The fee deducted by the DAF or platform before the gift reaches you, in the smallest currency unit. Defaults to 0.
+                effective_date:
+                  type: string
+                  format: date-time
+                  description: When the gift was made. Defaults to the current time.
+                primary_donor:
+                  $ref: "#/components/schemas/CreateDonor"
+                donor_advised_fund_grant:
+                  $ref: "#/components/schemas/CreateDafGrant"
+                corporate_match:
+                  $ref: "#/components/schemas/CreateCorporateMatch"
+                dafpay_tracking_id:
+                  type: string
+                  description: A DAFpay tracking identifier for reconciliation.
+                purpose:
+                  type: string
+                  description: The donor-stated purpose of the gift.
+                note:
+                  type: string
+                  description: A free-text note on the gift.
+                platform_metadata:
+                  type: object
+                  additionalProperties: true
+                  description: Arbitrary key-value metadata from the originating platform.
+                simulation_batch_id:
+                  type: string
+                  description: An optional handle that links this donation to a simulated deposit (or to other simulated donations) so they reconcile together. Leave it empty to have Chariot generate one, or pass the simulation_batch_id returned by a simulated deposit or donation. Up to 17 characters.
+      responses:
+        "200":
+          description: The simulated donation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimulateDonationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/simulations/deposits:
     post:
       summary: "Sandbox: Simulate a Deposit"
       description: |-
-        Simulate a deposit arriving on a payment source.
-        The deposit is created asynchronously through the standard processing pipeline.
+        Simulate money arriving on a payment source, the same way a real deposit would. The deposit is created shortly after you call this endpoint and lands in a pending state, ready to be completed or failed.
+
+        To settle simulated donations against this deposit, pass the `simulation_batch_id` returned by the Simulate a Donation endpoint (or leave it empty and reuse the value Chariot generates). See [Simulating gift processing](/guides/processing/sandbox) for a full walkthrough.
 
         <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
         This API is only available in the sandbox environment.
@@ -2927,19 +3012,19 @@ paths:
               properties:
                 payment_source_id:
                   type: string
-                  description: The payment source the deposit should arrive on.
+                  description: The payment source the deposit is arriving on.
                   example: "payment_source_01j8rs605a4gctmbm58d87mvsj"
                 amount:
                   type: string
                   format: int64
-                  description: The deposit amount in cents. Must be positive.
+                  description: The deposit amount, in the smallest currency unit (for example, cents). Must be positive.
                   example: "5000"
                 idempotency_key:
                   type: string
-                  description: Optional idempotency key. When set, repeating the call does not create a second deposit. When empty, every call creates a new deposit.
+                  description: An optional idempotency key. When set, repeating the call will not create a second deposit; when empty, each call creates a new deposit.
                 simulation_batch_id:
                   type: string
-                  description: Groups this deposit with simulated donations so it reconciles against them, standing in for the ACH batch the bank would otherwise assign. Leave empty to mint a fresh one, or set it to the simulation_batch_id of one or more simulated donations. Capped at 17 characters.
+                  description: An optional handle that links this deposit to simulated donations so they reconcile together. Leave it empty to have Chariot generate one, or pass the simulation_batch_id returned by a simulated donation to settle it against this deposit. Up to 17 characters.
       responses:
         "202":
           description: The deposit simulation request was accepted
@@ -2957,9 +3042,7 @@ paths:
     post:
       summary: "Sandbox: Complete a Deposit"
       description: |-
-        Advances a pending deposit to complete, as though the bank cleared its incoming transfer (e.g. a mailed check clearing).
-        Its funds become available and its donations become received.
-        The state change settles asynchronously through the standard processing pipeline.
+        Complete a pending deposit, as though its funds cleared (for example, a mailed check clearing). The deposit's funds become available and any donations reconciled against it are marked as received.
 
         <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
         This API is only available in the sandbox environment.
@@ -2994,9 +3077,7 @@ paths:
     post:
       summary: "Sandbox: Fail a Deposit"
       description: |-
-        Advances a pending deposit to failed, as though its incoming transfer was returned (e.g. a mailed check bouncing).
-        Its donations are reversed.
-        The state change settles asynchronously through the standard processing pipeline.
+        Fail a pending deposit, as though its funds were returned (for example, a mailed check bouncing). Any donations reconciled against it are reversed.
 
         <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
         This API is only available in the sandbox environment.
@@ -4408,6 +4489,73 @@ components:
             A subhash containing information about the joint donor of the donation.
           allOf:
             - $ref: "#/components/schemas/Donor"
+    CreateAddress:
+      type: object
+      description: A mailing address for a simulated donor.
+      properties:
+        line1:
+          type: string
+        line2:
+          type: string
+        city:
+          type: string
+        state:
+          type: string
+        postal_code:
+          type: string
+        country:
+          type: string
+    CreateDonor:
+      type: object
+      description: Donor information for a simulated donation.
+      properties:
+        full_name:
+          type: string
+        first_name:
+          type: string
+        last_name:
+          type: string
+        email:
+          type: string
+        phone:
+          type: string
+        address:
+          $ref: "#/components/schemas/CreateAddress"
+    CreateDafGrant:
+      type: object
+      description: DAF grant information, when a simulated gift came from a donor-advised fund.
+      properties:
+        organization_name:
+          type: string
+        donor_fund_name:
+          type: string
+        program_name:
+          type: string
+    CreateCorporateMatch:
+      type: object
+      description: Corporate match information, when a simulated gift was matched by an employer.
+      properties:
+        amount:
+          type: string
+          format: int64
+          description: The amount of the corporate match, in the smallest currency unit (for example, cents).
+        company_name:
+          type: string
+        program_name:
+          type: string
+        source:
+          type: string
+    SimulateDonationResponse:
+      type: object
+      description: The result of simulating a donation.
+      properties:
+        donation_id:
+          type: string
+          description: The identifier of the created donation. On a repeated idempotent call, the identifier of the existing donation.
+          example: "donation_01j8rs605a4gctmbm58d87mvsj"
+        simulation_batch_id:
+          type: string
+          description: The handle this donation was grouped under. Reuse it on a simulated deposit (or another simulated donation) to reconcile them together. Persist it, as it cannot be read back from the donation later.
     CorporateMatch:
       type: object
       description: |-

--- a/specs/2026-04-01.yaml
+++ b/specs/2026-04-01.yaml
@@ -2900,214 +2900,6 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /v1/simulations/donations:
-    post:
-      summary: "Sandbox: Simulate a Donation"
-      description: |-
-        Simulate a donation arriving on a payment source, the same way a real gift from a connected platform would.
-
-        The response returns a `simulation_batch_id`. Pass that value to the Simulate a Deposit endpoint (or to another Simulate a Donation call) to group them together, so the donation reconciles and settles against that deposit's funds. Order does not matter: you can create the deposit or the donation first.
-
-        See [Simulating gift processing](/guides/processing/sandbox) for a full walkthrough.
-
-        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
-        This API is only available in the sandbox environment.
-        </Note>
-      operationId: simulateDonation
-      tags:
-        - donations
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - payment_source_id
-                - amount_gross
-              properties:
-                payment_source_id:
-                  type: string
-                  description: The payment source the donation is arriving on.
-                  example: "payment_source_01j8rs605a4gctmbm58d87mvsj"
-                amount_gross:
-                  type: string
-                  format: int64
-                  description: The gross gift amount, in the smallest currency unit (for example, cents). Must be positive.
-                  example: "5000"
-                amount_fee:
-                  type: string
-                  format: int64
-                  description: The fee deducted by the DAF or platform before the gift reaches you, in the smallest currency unit. Defaults to 0.
-                effective_date:
-                  type: string
-                  format: date-time
-                  description: When the gift was made. Defaults to the current time.
-                primary_donor:
-                  $ref: "#/components/schemas/CreateDonor"
-                donor_advised_fund_grant:
-                  $ref: "#/components/schemas/CreateDafGrant"
-                corporate_match:
-                  $ref: "#/components/schemas/CreateCorporateMatch"
-                dafpay_tracking_id:
-                  type: string
-                  description: A DAFpay tracking identifier for reconciliation.
-                purpose:
-                  type: string
-                  description: The donor-stated purpose of the gift.
-                note:
-                  type: string
-                  description: A free-text note on the gift.
-                platform_metadata:
-                  type: object
-                  additionalProperties: true
-                  description: Arbitrary key-value metadata from the originating platform.
-                simulation_batch_id:
-                  type: string
-                  description: An optional handle that links this donation to a simulated deposit (or to other simulated donations) so they reconcile together. Leave it empty to have Chariot generate one, or pass the simulation_batch_id returned by a simulated deposit or donation. Up to 17 characters.
-      responses:
-        "200":
-          description: The simulated donation
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SimulateDonationResponse"
-        "400":
-          $ref: "#/components/responses/BadRequestError"
-        "401":
-          $ref: "#/components/responses/AuthenticationError"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-  /v1/simulations/deposits:
-    post:
-      summary: "Sandbox: Simulate a Deposit"
-      description: |-
-        Simulate money arriving on a payment source, the same way a real deposit would. The deposit is created shortly after you call this endpoint and lands in a pending state, ready to be completed or failed.
-
-        To settle simulated donations against this deposit, pass the `simulation_batch_id` returned by the Simulate a Donation endpoint (or leave it empty and reuse the value Chariot generates). See [Simulating gift processing](/guides/processing/sandbox) for a full walkthrough.
-
-        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
-        This API is only available in the sandbox environment.
-        </Note>
-      operationId: simulateDeposit
-      tags:
-        - deposits
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - payment_source_id
-                - amount
-              properties:
-                payment_source_id:
-                  type: string
-                  description: The payment source the deposit is arriving on.
-                  example: "payment_source_01j8rs605a4gctmbm58d87mvsj"
-                amount:
-                  type: string
-                  format: int64
-                  description: The deposit amount, in the smallest currency unit (for example, cents). Must be positive.
-                  example: "5000"
-                idempotency_key:
-                  type: string
-                  description: An optional idempotency key. When set, repeating the call will not create a second deposit; when empty, each call creates a new deposit.
-                simulation_batch_id:
-                  type: string
-                  description: An optional handle that links this deposit to simulated donations so they reconcile together. Leave it empty to have Chariot generate one, or pass the simulation_batch_id returned by a simulated donation to settle it against this deposit. Up to 17 characters.
-      responses:
-        "202":
-          description: The deposit simulation request was accepted
-        "400":
-          $ref: "#/components/responses/BadRequestError"
-        "401":
-          $ref: "#/components/responses/AuthenticationError"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-  /v1/simulations/deposits/{id}/complete:
-    post:
-      summary: "Sandbox: Complete a Deposit"
-      description: |-
-        Complete a pending deposit, as though its funds cleared (for example, a mailed check clearing). The deposit's funds become available and any donations reconciled against it are marked as received.
-
-        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
-        This API is only available in the sandbox environment.
-        </Note>
-      operationId: simulateDepositCompletion
-      tags:
-        - deposits
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          description: The unique identifier for the deposit
-          required: true
-          schema:
-            type: string
-          example: "deposit_01j8rs605a4gctmbm58d87mvsj"
-      responses:
-        "202":
-          description: The deposit completion request was accepted
-        "400":
-          $ref: "#/components/responses/BadRequestError"
-        "401":
-          $ref: "#/components/responses/AuthenticationError"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-  /v1/simulations/deposits/{id}/fail:
-    post:
-      summary: "Sandbox: Fail a Deposit"
-      description: |-
-        Fail a pending deposit, as though its funds were returned (for example, a mailed check bouncing). Any donations reconciled against it are reversed.
-
-        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
-        This API is only available in the sandbox environment.
-        </Note>
-      operationId: simulateDepositFailure
-      tags:
-        - deposits
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          description: The unique identifier for the deposit
-          required: true
-          schema:
-            type: string
-          example: "deposit_01j8rs605a4gctmbm58d87mvsj"
-      responses:
-        "202":
-          description: The deposit failure request was accepted
-        "400":
-          $ref: "#/components/responses/BadRequestError"
-        "401":
-          $ref: "#/components/responses/AuthenticationError"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
   /v1/payment_sources:
     get:
       summary: List Payment Sources
@@ -3294,6 +3086,90 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/donations:
+    post:
+      summary: "Sandbox: Simulate a Donation"
+      description: |-
+        Simulate a donation arriving on a payment source, the same way a real gift from a connected platform would.
+
+        The response returns a `simulation_batch_id`. Pass that value to the Simulate a Deposit endpoint (or to another Simulate a Donation call) to group them together, so the donation reconciles and settles against that deposit's funds. Order does not matter: you can create the deposit or the donation first.
+
+        See [Simulating gift processing](/guides/processing/sandbox) for a full walkthrough.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: simulateDonation
+      tags:
+        - donations
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - payment_source_id
+                - amount_gross
+              properties:
+                payment_source_id:
+                  type: string
+                  description: The payment source the donation is arriving on.
+                  example: "payment_source_01j8rs605a4gctmbm58d87mvsj"
+                amount_gross:
+                  type: string
+                  format: int64
+                  description: The gross gift amount, in the smallest currency unit (for example, cents). Must be positive.
+                  example: "5000"
+                amount_fee:
+                  type: string
+                  format: int64
+                  description: The fee deducted by the DAF or platform before the gift reaches you, in the smallest currency unit. Defaults to 0.
+                effective_date:
+                  type: string
+                  format: date-time
+                  description: When the gift was made. Defaults to the current time.
+                primary_donor:
+                  $ref: "#/components/schemas/CreateDonor"
+                donor_advised_fund_grant:
+                  $ref: "#/components/schemas/CreateDafGrant"
+                corporate_match:
+                  $ref: "#/components/schemas/CreateCorporateMatch"
+                dafpay_tracking_id:
+                  type: string
+                  description: A DAFpay tracking identifier for reconciliation.
+                purpose:
+                  type: string
+                  description: The donor-stated purpose of the gift.
+                note:
+                  type: string
+                  description: A free-text note on the gift.
+                platform_metadata:
+                  type: object
+                  additionalProperties: true
+                  description: Arbitrary key-value metadata from the originating platform.
+                simulation_batch_id:
+                  type: string
+                  description: An optional handle that links this donation to a simulated deposit (or to other simulated donations) so they reconcile together. Leave it empty to have Chariot generate one, or pass the simulation_batch_id returned by a simulated deposit or donation. Up to 17 characters.
+      responses:
+        "200":
+          description: The simulated donation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimulateDonationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /v1/deposits:
     get:
       summary: List Deposits
@@ -3375,6 +3251,130 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Deposit"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/deposits:
+    post:
+      summary: "Sandbox: Simulate a Deposit"
+      description: |-
+        Simulate money arriving on a payment source, the same way a real deposit would. The deposit is created shortly after you call this endpoint and lands in a pending state, ready to be completed or failed.
+
+        To settle simulated donations against this deposit, pass the `simulation_batch_id` returned by the Simulate a Donation endpoint (or leave it empty and reuse the value Chariot generates). See [Simulating gift processing](/guides/processing/sandbox) for a full walkthrough.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: simulateDeposit
+      tags:
+        - deposits
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - payment_source_id
+                - amount
+              properties:
+                payment_source_id:
+                  type: string
+                  description: The payment source the deposit is arriving on.
+                  example: "payment_source_01j8rs605a4gctmbm58d87mvsj"
+                amount:
+                  type: string
+                  format: int64
+                  description: The deposit amount, in the smallest currency unit (for example, cents). Must be positive.
+                  example: "5000"
+                idempotency_key:
+                  type: string
+                  description: An optional idempotency key. When set, repeating the call will not create a second deposit; when empty, each call creates a new deposit.
+                simulation_batch_id:
+                  type: string
+                  description: An optional handle that links this deposit to simulated donations so they reconcile together. Leave it empty to have Chariot generate one, or pass the simulation_batch_id returned by a simulated donation to settle it against this deposit. Up to 17 characters.
+      responses:
+        "202":
+          description: The deposit simulation request was accepted
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/deposits/{id}/complete:
+    post:
+      summary: "Sandbox: Complete a Deposit"
+      description: |-
+        Complete a pending deposit, as though its funds cleared (for example, a mailed check clearing). The deposit's funds become available and any donations reconciled against it are marked as received.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: simulateDepositCompletion
+      tags:
+        - deposits
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier for the deposit
+          required: true
+          schema:
+            type: string
+          example: "deposit_01j8rs605a4gctmbm58d87mvsj"
+      responses:
+        "202":
+          description: The deposit completion request was accepted
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "401":
+          $ref: "#/components/responses/AuthenticationError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /v1/simulations/deposits/{id}/fail:
+    post:
+      summary: "Sandbox: Fail a Deposit"
+      description: |-
+        Fail a pending deposit, as though its funds were returned (for example, a mailed check bouncing). Any donations reconciled against it are reversed.
+
+        <Note title="Sandbox Only" icon="fa-light fa-atom-simple">
+        This API is only available in the sandbox environment.
+        </Note>
+      operationId: simulateDepositFailure
+      tags:
+        - deposits
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier for the deposit
+          required: true
+          schema:
+            type: string
+          example: "deposit_01j8rs605a4gctmbm58d87mvsj"
+      responses:
+        "202":
+          description: The deposit failure request was accepted
         "400":
           $ref: "#/components/responses/BadRequestError"
         "401":


### PR DESCRIPTION
The sandbox now lets integrators drive an incoming gift through its whole lifecycle. These simulation routes are not yet reflected in the public API reference, so anyone reading the docs had no way to discover or call them.

This includes:

- POST /v1/simulations/donations
- POST /v1/simulations/deposits
- POST /v1/simulations/deposits/{id}/complete
- POST /v1/simulations/deposits/{id}/fail

Only the REST-exposed, non-internal routes are documented. The other simulation RPCs in that PR (source/mailbox connect, inbound ACH, check-deposit clear/return) are marked internal and intentionally left out of the public spec.
