### PR TITLE
docs(webhooks): clarify event subscriptions are scoped to the api key that creates them

### DIFF
--- a/fern/versions/v2026-04-01/pages/api/webhooks-and-events.mdx
+++ b/fern/versions/v2026-04-01/pages/api/webhooks-and-events.mdx
@@ -9,6 +9,10 @@ When something interesting happens on the nonprofit's Chariot account, such as a
 
 The first step is to create an Event Subscription via the [API](/api/event-subscriptions/create). As part of this, you specify a URL for a server endpoint that will receive real-time events. Chariot will then send HTTPS requests to that URL to notify you of activity for certain events.
 
+<Note>
+An Event Subscription only receives events for the account of the API key that creates it. If you integrate with a single organization API key, that key receives all of your organization's events, including both grant and donation events. Create the subscription with the same key you use to call the API, and do not expect a subscription created with one key to receive another key's events.
+</Note>
+
 When a noteworthy event happens, Chariot first generates an [Event](/api/events/get). Next, we'll send a POST request to your endpoint.
 
 <Aside>


### PR DESCRIPTION
AI-GENERATED: aligns the webhook docs with the org-key changes (ENG-4862 / ENG-4863).

Now that a nonprofit can integrate with a single organization key (capture grants and receive both grant and donation events on that one key), the most common footgun is subscribing with the wrong key. One customer subscribed to donation events with their fundraising-application key, which never receives donation events, so nothing delivered.

This adds a short note to the Webhooks and Events page: a subscription only receives events for the account of the key that creates it, so create the subscription with the same key you use to call the API. No spec changes, since the endpoint shapes and scopes are unchanged.

Holding the larger guide update (documenting the full single-organization-key DAFpay flow with no fundraising application) until the rest of that milestone ships, so we are not documenting a path a nonprofit cannot fully self-serve yet.